### PR TITLE
[CSV-158] Fix EOL checking for read array in ExtendedBufferedReader

### DIFF
--- a/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
+++ b/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
@@ -164,7 +164,7 @@ final class ExtendedBufferedReader extends BufferedReader {
             for (int i = offset; i < offset + len; i++) {
                 final char ch = buf[i];
                 if (ch == LF) {
-                    if (CR != (i > 0 ? buf[i - 1] : lastChar)) {
+                    if (CR != (i > offset ? buf[i - 1] : lastChar)) {
                         eolCounter++;
                     }
                 } else if (ch == CR) {

--- a/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
+++ b/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
@@ -204,6 +204,15 @@ public class ExtendedBufferedReaderTest {
         }
     }
 
+    @Test
+    public void testReadingInDifferentBuffer() throws Exception {
+        char[] tmp1 = new char[2], tmp2 = new char[4];
+        ExtendedBufferedReader br = createBufferedReader("1\r\n2\r\n");
+        br.read(tmp1, 0, 2);
+        br.read(tmp2, 2, 2);
+        assertEquals(2, br.getCurrentLineNumber());
+    }
+
     private ExtendedBufferedReader createBufferedReader(final String s) {
         return new ExtendedBufferedReader(new StringReader(s));
     }


### PR DESCRIPTION
Characters in buffer before offset are unspecified
