### PR TITLE
[CSV-153] CSVPrinter skips creation of header with skipHeaderRecord=true

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVPrinter.java
+++ b/src/main/java/org/apache/commons/csv/CSVPrinter.java
@@ -73,7 +73,7 @@ public final class CSVPrinter implements Flushable, Closeable {
                 }
             }
         }
-        if (format.getHeader() != null) {
+        if (format.getHeader() != null && !format.getSkipHeaderRecord()) {
             this.printRecord((Object[]) format.getHeader());
         }
     }

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -558,6 +558,40 @@ public class CSVPrinterTest {
     }
 
     @Test
+    public void testHeaderNotSet() throws IOException {
+        final StringWriter sw = new StringWriter();
+        final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null));
+        printer.printRecord("a", "b", "c");
+        printer.printRecord("x", "y", "z");
+        assertEquals("a,b,c\r\nx,y,z\r\n", sw.toString());
+        printer.close();
+    }
+
+    @Test
+    public void testSkipHeaderRecordTrue() throws IOException {
+    	// functionally identical to testHeaderNotSet, used to test CSV-153
+        final StringWriter sw = new StringWriter();
+        final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null)
+                .withHeader("C1", "C2", "C3").withSkipHeaderRecord(true));
+        printer.printRecord("a", "b", "c");
+        printer.printRecord("x", "y", "z");
+        assertEquals("a,b,c\r\nx,y,z\r\n", sw.toString());
+        printer.close();
+    }
+
+    @Test
+    public void testSkipHeaderRecordFalse() throws IOException {
+    	// functionally identical to testHeader, used to test CSV-153
+        final StringWriter sw = new StringWriter();
+        final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null)
+                .withHeader("C1", "C2", "C3").withSkipHeaderRecord(false));
+        printer.printRecord("a", "b", "c");
+        printer.printRecord("x", "y", "z");
+        assertEquals("C1,C2,C3\r\na,b,c\r\nx,y,z\r\n", sw.toString());
+        printer.close();
+    }
+
+    @Test
     public void testHeaderCommentExcel() throws IOException {
         final StringWriter sw = new StringWriter();
         final Date now = new Date();


### PR DESCRIPTION
Prior behavior is that the creation of header occurs only if header is set in CSVFormat. Now it's created if header is set (not null) and skipHeaderRecord is false.

    if (format.getHeader() != null && !format.getSkipHeaderRecord()) {
        this.printRecord((Object[]) format.getHeader());
    }