### PR TITLE
Fix outdated comments about FileReader

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -138,11 +138,6 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     /**
      * Creates a parser for the given {@link File}.
      *
-     * <p><strong>Note:</strong> This method internally creates a FileReader using
-     * {@link java.io.FileReader#FileReader(java.io.File)} which in turn relies on the default encoding of the JVM that
-     * is executing the code. If this is insufficient create a URL to the file and use
-     * {@link #parse(URL, Charset, CSVFormat)}</p>
-     *
      * @param file
      *            a CSV file. Must not be null.
      * @param charset
@@ -192,12 +187,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     }
 
     /**
-     * Creates a parser for the given {@link File}.
-     *
-     * <p><strong>Note:</strong> This method internally creates a FileReader using
-     * {@link java.io.FileReader#FileReader(java.io.File)} which in turn relies on the default encoding of the JVM that
-     * is executing the code. If this is insufficient create a URL to the file and use
-     * {@link #parse(URL, Charset, CSVFormat)}</p>
+     * Creates a parser for the given {@link Path}.
      *
      * @param path
      *            a CSV file. Must not be null.


### PR DESCRIPTION
The comments mention that the constructor that takes a File or Path internally creates a FileReader with the JVM's default CharSet. This is not the case: it instead creates an InputStreamReader with the specified charset. I've removed the incorrect comments.