### PR TITLE
Proposal: New option to distinguish null from empty string

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -232,7 +232,7 @@ public final class CSVFormat implements Serializable {
      * @see Predefined#Default
      */
     public static final CSVFormat DEFAULT = new CSVFormat(COMMA, DOUBLE_QUOTE_CHAR, null, null, null, false, true, CRLF,
-            null, null, null, false, false, false, false, false);
+            null, null, null, false, false, false, false, false, false);
 
     /**
      * Excel file format (using a comma as the value delimiter). Note that the actual value delimiter used by Excel is
@@ -427,7 +427,7 @@ public final class CSVFormat implements Serializable {
      */
     public static CSVFormat newFormat(final char delimiter) {
         return new CSVFormat(delimiter, null, null, null, null, false, false, null, null, null, null, false, false,
-                false, false, false);
+                false, false, false, false);
     }
 
     /**
@@ -474,6 +474,8 @@ public final class CSVFormat implements Serializable {
 
     private final boolean trim;
 
+    private final boolean missingColumnValuesAreNull; // use null if encounter missing values
+
     /**
      * Creates a customized CSV format.
      *
@@ -509,6 +511,8 @@ public final class CSVFormat implements Serializable {
      *            TODO
      * @param trailingDelimiter
      *            TODO
+     * @param missingColumnValuesAreNull
+     *            use null if encounter missing values
      * @throws IllegalArgumentException
      *             if the delimiter is a line break character
      */
@@ -517,7 +521,7 @@ public final class CSVFormat implements Serializable {
             final boolean ignoreEmptyLines, final String recordSeparator, final String nullString,
             final Object[] headerComments, final String[] header, final boolean skipHeaderRecord,
             final boolean allowMissingColumnNames, final boolean ignoreHeaderCase, final boolean trim,
-            final boolean trailingDelimiter) {
+            final boolean trailingDelimiter, final boolean missingColumnValuesAreNull) {
         this.delimiter = delimiter;
         this.quoteCharacter = quoteChar;
         this.quoteMode = quoteMode;
@@ -534,6 +538,7 @@ public final class CSVFormat implements Serializable {
         this.ignoreHeaderCase = ignoreHeaderCase;
         this.trailingDelimiter = trailingDelimiter;
         this.trim = trim;
+        this.missingColumnValuesAreNull = missingColumnValuesAreNull;
         validate();
     }
 
@@ -775,6 +780,16 @@ public final class CSVFormat implements Serializable {
      */
     public boolean getTrim() {
         return trim;
+    }
+
+    /**
+     * Returns whether to use null for missing column values.
+     *
+     * @return whether to use null for missing column values.
+     * @since 1.5
+     */
+    public boolean getMissingColumnValuesAreNull() {
+        return missingColumnValuesAreNull;
     }
 
     @Override
@@ -1311,7 +1326,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withAllowMissingColumnNames(final boolean allowMissingColumnNames) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1346,7 +1362,8 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1364,7 +1381,8 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1395,7 +1413,7 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escape, ignoreSurroundingSpaces,
                 ignoreEmptyLines, recordSeparator, nullString, headerComments, header, skipHeaderRecord,
-                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, missingColumnValuesAreNull);
     }
 
     /**
@@ -1550,7 +1568,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withHeader(final String... header) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1571,7 +1590,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withHeaderComments(final Object... headerComments) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1596,7 +1616,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withIgnoreEmptyLines(final boolean ignoreEmptyLines) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1622,7 +1643,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withIgnoreHeaderCase(final boolean ignoreHeaderCase) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1647,7 +1669,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withIgnoreSurroundingSpaces(final boolean ignoreSurroundingSpaces) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1666,7 +1689,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withNullString(final String nullString) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1697,7 +1721,7 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteChar, quoteMode, commentMarker, escapeCharacter, ignoreSurroundingSpaces,
                 ignoreEmptyLines, recordSeparator, nullString, headerComments, header, skipHeaderRecord,
-                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, missingColumnValuesAreNull);
     }
 
     /**
@@ -1711,7 +1735,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withQuoteMode(final QuoteMode quoteModePolicy) {
         return new CSVFormat(delimiter, quoteCharacter, quoteModePolicy, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1749,7 +1774,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withRecordSeparator(final String recordSeparator) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1776,7 +1802,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withSkipHeaderRecord(final boolean skipHeaderRecord) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1801,7 +1828,8 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withTrailingDelimiter(final boolean trailingDelimiter) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 
     /**
@@ -1826,6 +1854,34 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withTrim(final boolean trim) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
+    }
+
+    /**
+     * Returns a new {@code CSVFormat} to use null for missing column values.
+     *
+     * @return A new CSVFormat that is equal to this but with the use
+     * null for missing column values on.
+     * @since 1.5
+     */
+    public CSVFormat withMissingColumnValuesAreNull() {
+        return withMissingColumnValuesAreNull(true);
+    }
+
+    /**
+     * Returns a new {@code CSVFormat} with whether to use null for missing column values.
+     *
+     * @param missingColumnValuesAreNull
+     *            whether to use null for missing column values.
+     *
+     * @return A new CSVFormat that is equal to this but with the specified setting.
+     * @since 1.5
+     */
+    public CSVFormat withMissingColumnValuesAreNull(final boolean missingColumnValuesAreNull) {
+        return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter,
+                missingColumnValuesAreNull);
     }
 }

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -367,8 +367,25 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         if (lastRecord && inputClean.isEmpty() && this.format.getTrailingDelimiter()) {
             return;
         }
-        final String nullString = this.format.getNullString();
-        this.record.add(inputClean.equals(nullString) ? null : inputClean);
+        this.record.add(isNull(inputClean) ? null : inputClean);
+    }
+
+    private boolean isNull(final String input) {
+        Assertions.notNull(input, "input");
+
+        if (input.equals(this.format.getNullString())) {
+            return true;
+        }
+
+        if (!this.format.getMissingColumnValuesAreNull()) {
+            return false; // MUST keep backward compatibility
+        }
+
+        if (this.reusableToken.isQuoted) {
+            return false; // distinguish quoted strings from null
+        }
+
+        return input.isEmpty();
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -150,6 +150,7 @@ final class Lexer implements Closeable {
             } else if (isQuoteChar(c)) {
                 // consume encapsulated token
                 parseEncapsulatedToken(token);
+                token.isQuoted = true;
             } else if (isEndOfFile(c)) {
                 // end of file return EOF()
                 // noop: token.content.append("");

--- a/src/main/java/org/apache/commons/csv/Token.java
+++ b/src/main/java/org/apache/commons/csv/Token.java
@@ -57,10 +57,14 @@ final class Token {
     /** Token ready flag: indicates a valid token with content (ready for the parser). */
     boolean isReady;
 
+    /** Indicates whether token is quoted or not */
+    boolean isQuoted;
+
     void reset() {
         content.setLength(0);
         type = INVALID;
         isReady = false;
+        isQuoted = false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -459,6 +459,12 @@ public class CSVFormatTest {
         assertTrue(formatWithFirstRecordAsHeader.getHeader().length == 0);
     }
 
+    @Test
+    public void testWithMissingColumnValuesAreNull() {
+        final CSVFormat format = CSVFormat.DEFAULT.withMissingColumnValuesAreNull();
+        assertTrue(format.getMissingColumnValuesAreNull());
+    }
+
     public enum Header {
         Name, Email, Phone
     }

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -961,6 +961,47 @@ public class CSVParserTest {
         Assert.assertEquals(3, record.size());
     }
 
+    @Test
+    public void testMissingColumnValuesAreNull() throws Exception {
+        final String code = ",,\"\",";
+
+        // check backward compatibility
+        try (final CSVParser parser = CSVParser.parse(code, CSVFormat.DEFAULT)) {
+            final CSVRecord record = parser.iterator().next();
+
+            assertNotNull(record.get(0));
+            assertNotNull(record.get(1));
+            assertNotNull(record.get(2));
+            assertNotNull(record.get(3));
+            Assert.assertEquals(4, record.size());
+        }
+
+        // check withMissingColumnValuesAreNull
+        try (final CSVParser parser = CSVParser.parse(code, CSVFormat.DEFAULT
+                .withMissingColumnValuesAreNull())) {
+            final CSVRecord record = parser.iterator().next();
+
+            assertNull(record.get(0));
+            assertNull(record.get(1));
+            assertNotNull(record.get(2));
+            assertNull(record.get(3));
+            Assert.assertEquals(4, record.size());
+        }
+
+        // check combination of withNullString and withMissingColumnValuesAreNull
+        try (final CSVParser parser = CSVParser.parse(code, CSVFormat.DEFAULT
+                .withNullString("")
+                .withMissingColumnValuesAreNull())) {
+            final CSVRecord record = parser.iterator().next();
+
+            assertNull(record.get(0));
+            assertNull(record.get(1));
+            assertNull(record.get(2));
+            assertNull(record.get(3));
+            Assert.assertEquals(4, record.size());
+        }
+    }
+
     private void validateLineNumbers(final String lineSeparator) throws IOException {
         try (final CSVParser parser = CSVParser.parse("a" + lineSeparator + "b" + lineSeparator + "c",
                 CSVFormat.DEFAULT.withRecordSeparator(lineSeparator))) {

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -27,7 +27,9 @@ import static org.apache.commons.csv.Token.Type.EOF;
 import static org.apache.commons.csv.Token.Type.EORECORD;
 import static org.apache.commons.csv.Token.Type.TOKEN;
 import static org.apache.commons.csv.TokenMatchers.hasContent;
+import static org.apache.commons.csv.TokenMatchers.isQuoted;
 import static org.apache.commons.csv.TokenMatchers.matches;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -387,6 +389,19 @@ public class LexerTest {
         final String code = "escaping at EOF is evil\\";
         try (final Lexer lexer = createLexer(code, formatWithEscaping)) {
             lexer.nextToken(new Token());
+        }
+    }
+
+    @Test
+    public void testQuotedToken() throws Exception {
+        final String code = ",,\"\",";
+
+        try (final Lexer lexer = createLexer(code, CSVFormat.DEFAULT)) {
+            assertThat(lexer.nextToken(new Token()), not(isQuoted()));
+            assertThat(lexer.nextToken(new Token()), not(isQuoted()));
+            assertThat(lexer.nextToken(new Token()), isQuoted());
+            assertThat(lexer.nextToken(new Token()), not(isQuoted()));
+            assertThat(lexer.nextToken(new Token()), matches(EOF, ""));
         }
     }
 }

--- a/src/test/java/org/apache/commons/csv/TokenMatchers.java
+++ b/src/test/java/org/apache/commons/csv/TokenMatchers.java
@@ -82,6 +82,23 @@ final class TokenMatchers {
         };
     }
 
+    public static Matcher<Token> isQuoted() {
+        return new TypeSafeDiagnosingMatcher<Token>() {
+
+            @Override
+            public void describeTo(final Description description) {
+                description.appendText("token is quoted ");
+            }
+
+            @Override
+            protected boolean matchesSafely(final Token item,
+                    final Description mismatchDescription) {
+                mismatchDescription.appendText("token is not quoted ");
+                return item.isQuoted;
+            }
+        };
+    }
+
     public static Matcher<Token> matches(final Token.Type expectedType, final String expectedContent) {
         return allOf(hasType(expectedType), hasContent(expectedContent));
     }

--- a/src/test/java/org/apache/commons/csv/TokenMatchersTest.java
+++ b/src/test/java/org/apache/commons/csv/TokenMatchersTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.csv;
 import static org.apache.commons.csv.TokenMatchers.hasContent;
 import static org.apache.commons.csv.TokenMatchers.hasType;
 import static org.apache.commons.csv.TokenMatchers.isReady;
+import static org.apache.commons.csv.TokenMatchers.isQuoted;
 import static org.apache.commons.csv.TokenMatchers.matches;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -35,6 +36,7 @@ public class TokenMatchersTest {
         token = new Token();
         token.type = Token.Type.TOKEN;
         token.isReady = true;
+        token.isQuoted = true;
         token.content.append("content");
     }
 
@@ -57,6 +59,13 @@ public class TokenMatchersTest {
         assertTrue(isReady().matches(token));
         token.isReady = false;
         assertFalse(isReady().matches(token));
+    }
+
+    @Test
+    public void testIsQuoted() {
+        assertTrue(isQuoted().matches(token));
+        token.isQuoted = false;
+        assertFalse(isQuoted().matches(token));
     }
 
     @Test


### PR DESCRIPTION
It is critical to distinguish null from empty string for accomplishing data migration between different RDBMS using csv files.

Unfortunately, CSVParser does not support this functionality and returns ["", "", "", ""] as a result of parsing ",,\\"\\",". Thus, it impossible to make nullable columns have null instead of empty string when importing data from csv files.

So I'd like to add a new option to distinguish them.

- CSVFormat.withMissingColumnValuesAreNull()

With this option on, you can get [null, null, "", null] as a result of above input data. Its default value is off and CSVParser keeps backward compatibility.