### PR TITLE
CSV-214: adding cache for the line ending information

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -358,7 +358,16 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         this.characterOffset = characterOffset;
         this.recordNumber = recordNumber - 1;
     }
-
+    /**
+    * Return the line ending information cached in the internal Lexer object
+     * <p>
+     *   Once you have parsed atleast one line then the internal lexer object would have cached the line ending
+     *   value. This is useful for modifying and writing back files.
+     * </p>
+    */
+    public String getLineEndingFromLexer(){
+        return lexer.getLineEnding();
+    }
     private void addRecordValue(final boolean lastRecord) {
         final String input = this.reusableToken.content.toString();
         final String inputClean = this.format.getTrim() ? input.trim() : input;

--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -57,6 +57,14 @@ final class Lexer implements Closeable {
 
     /** The input stream */
     private final ExtendedBufferedReader reader;
+    private String lineEnding;
+    private boolean isLESet = false;
+    public String getLineEnding(){
+        return lineEnding;
+    }
+    private void setLineEnding(String input){
+        lineEnding = input;
+    }
 
     Lexer(final CSVFormat format, final ExtendedBufferedReader reader) {
         this.reader = reader;
@@ -374,7 +382,18 @@ final class Lexer implements Closeable {
         if (ch == CR && reader.lookAhead() == LF) {
             // note: does not change ch outside of this method!
             ch = reader.read();
+            //save the CRLF state here
+            if(!isLESet) {
+                setLineEnding(Constants.CRLF);
+                isLESet = true;
+            }
         }
+        //save LF state here.
+        if(!isLESet && ch == LF) {
+            setLineEnding(Character.toString(Constants.LF));
+            isLESet = true;
+        }
+
         return ch == LF || ch == CR;
     }
 

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -234,6 +234,24 @@ public class CSVParserTest {
             assertEquals(4, records.size());
         }
     }
+    @Test
+    public void testLineEndingsCacheWindows() throws IOException {
+        final String code = "foo\r\nbaar,\r\nhello,world\r\n,kanu";
+        final CSVParser parser = CSVParser.parse(code, CSVFormat.DEFAULT);
+        final List<CSVRecord> records = parser.getRecords();
+        assertEquals(4, records.size());
+        assertEquals("\r\n",parser.getLineEndingFromLexer());
+        parser.close();
+    }
+    @Test
+    public void testLineEndingsCacheLinux() throws IOException {
+        final String code = "foo\nbaar,\nhello,world\n,kanu";
+        final CSVParser parser = CSVParser.parse(code, CSVFormat.DEFAULT);
+        final List<CSVRecord> records = parser.getRecords();
+        assertEquals(4, records.size());
+        assertEquals("\n",parser.getLineEndingFromLexer());
+        parser.close();
+    }
 
     @Test(expected = NoSuchElementException.class)
     public void testClose() throws Exception {


### PR DESCRIPTION
Description copied here from the JIRA ticket.
In my use-case , I have to read a CSV file, Mangle some columns and then write out a new csv file with those mangled columns.
I have gone through the parser code and I have found no usable way of getting the line ending information from the CSVParser object. The function readEndOfLine just consumes End of line whether it is CRLF or LF.
Now that problem is that when I am writing my file back using the CSVPrinter, I need to know what line ending my input file was. I could write an external function to do that. A better way would be to store that information in the CSVParser object and just use it.
To do that I am just saving the state in a variable and exposing that using a getter.
I have done some basic testing. and Submitting a pull request regarding that.