### PR TITLE
CSV-216: Add mutator withValue() to CSVRecord

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -648,6 +648,7 @@ public final class CSVFormat implements Serializable {
         this.recordSeparator = recordSeparator;
         this.nullString = nullString;
         this.headerComments = toStringArray(headerComments);
+	// Note: .clone() is generally not-OK, but this is safe as Strings are immutable
         this.header = header == null ? null : header.clone();
         this.skipHeaderRecord = skipHeaderRecord;
         this.ignoreHeaderCase = ignoreHeaderCase;
@@ -798,6 +799,7 @@ public final class CSVFormat implements Serializable {
      * @return a copy of the header array; {@code null} if disabled, the empty array if to be read from the file
      */
     public String[] getHeader() {
+	// Note: .clone() is generally not-OK, but this is safe as Strings are immutable
         return header != null ? header.clone() : null;
     }
 

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -623,9 +623,10 @@ public final class CSVFormat implements Serializable {
      *            TODO
      * @param trailingDelimiter
      *            TODO
-     * @param mutableRecords TODO
      * @param autoFlush
      * 	TODO
+     * @param mutableRecords
+     * 	           if {@code true}, return {@link CSVMutableRecord} 
      * 
      * @throws IllegalArgumentException
      *             if the delimiter is a line break character

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -1788,7 +1788,7 @@ public final class CSVFormat implements Serializable {
      * @param mutableRecords
      *            whether to generate CSVRecord or CSVMutableRecord
      *
-     * @return A new CSVFormat that is equal to this but with the specified null conversion string.
+     * @return A new CSVFormat that is equal to this but with setting to generate CSVRecord or CSVMutableRecord.
      */
     public CSVFormat withMutableRecords(final boolean mutableRecords) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -242,7 +242,7 @@ public final class CSVFormat implements Serializable {
      * @see Predefined#Default
      */
     public static final CSVFormat DEFAULT = new CSVFormat(COMMA, DOUBLE_QUOTE_CHAR, null, null, null, false, true, CRLF,
-            null, null, null, false, false, false, false, false);
+            null, null, null, false, false, false, false, false, false);
 
     /**
      * Excel file format (using a comma as the value delimiter). Note that the actual value delimiter used by Excel is
@@ -537,7 +537,7 @@ public final class CSVFormat implements Serializable {
      */
     public static CSVFormat newFormat(final char delimiter) {
         return new CSVFormat(delimiter, null, null, null, null, false, false, null, null, null, null, false, false,
-                false, false, false);
+                false, false, false, false);
     }
 
     /**
@@ -570,6 +570,8 @@ public final class CSVFormat implements Serializable {
 
     private final boolean ignoreSurroundingSpaces; // Should leading/trailing spaces be ignored around values?
 
+    private final boolean mutableRecords;
+    
     private final String nullString; // the string to be used for null values
 
     private final Character quoteCharacter; // null if quoting is disabled
@@ -619,6 +621,7 @@ public final class CSVFormat implements Serializable {
      *            TODO
      * @param trailingDelimiter
      *            TODO
+     * @param mutableRecords TODO
      * @throws IllegalArgumentException
      *             if the delimiter is a line break character
      */
@@ -627,7 +630,7 @@ public final class CSVFormat implements Serializable {
             final boolean ignoreEmptyLines, final String recordSeparator, final String nullString,
             final Object[] headerComments, final String[] header, final boolean skipHeaderRecord,
             final boolean allowMissingColumnNames, final boolean ignoreHeaderCase, final boolean trim,
-            final boolean trailingDelimiter) {
+            final boolean trailingDelimiter, boolean mutableRecords) {
         this.delimiter = delimiter;
         this.quoteCharacter = quoteChar;
         this.quoteMode = quoteMode;
@@ -644,6 +647,7 @@ public final class CSVFormat implements Serializable {
         this.ignoreHeaderCase = ignoreHeaderCase;
         this.trailingDelimiter = trailingDelimiter;
         this.trim = trim;
+        this.mutableRecords = mutableRecords;
         validate();
     }
 
@@ -925,6 +929,10 @@ public final class CSVFormat implements Serializable {
      */
     public boolean isEscapeCharacterSet() {
         return escapeCharacter != null;
+    }
+
+    public boolean isMutableRecords() {
+        return mutableRecords;
     }
 
     /**
@@ -1431,7 +1439,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withAllowMissingColumnNames(final boolean allowMissingColumnNames) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1466,7 +1474,7 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1484,7 +1492,7 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1515,7 +1523,7 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escape, ignoreSurroundingSpaces,
                 ignoreEmptyLines, recordSeparator, nullString, headerComments, header, skipHeaderRecord,
-                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1670,7 +1678,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withHeader(final String... header) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1691,7 +1699,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withHeaderComments(final Object... headerComments) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1716,7 +1724,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withIgnoreEmptyLines(final boolean ignoreEmptyLines) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1742,7 +1750,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withIgnoreHeaderCase(final boolean ignoreHeaderCase) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1767,7 +1775,25 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withIgnoreSurroundingSpaces(final boolean ignoreSurroundingSpaces) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
+    }
+
+    /**
+     * Returns a new {@code CSVFormat} with whether to generate CSVRecord or CSVMutableRecord.
+     * <ul>
+     * <li><strong>Reading:</strong> Whether to generate CSVRecord or CSVMutableRecord.</li>
+     * <li><strong>Writing:</strong> No effect.</li>
+     * </ul>
+     *
+     * @param mutableRecords
+     *            whether to generate CSVRecord or CSVMutableRecord
+     *
+     * @return A new CSVFormat that is equal to this but with the specified null conversion string.
+     */
+    public CSVFormat withMutableRecords(final boolean mutableRecords) {
+        return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1786,7 +1812,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withNullString(final String nullString) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1817,7 +1843,7 @@ public final class CSVFormat implements Serializable {
         }
         return new CSVFormat(delimiter, quoteChar, quoteMode, commentMarker, escapeCharacter, ignoreSurroundingSpaces,
                 ignoreEmptyLines, recordSeparator, nullString, headerComments, header, skipHeaderRecord,
-                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1831,7 +1857,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withQuoteMode(final QuoteMode quoteModePolicy) {
         return new CSVFormat(delimiter, quoteCharacter, quoteModePolicy, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1869,7 +1895,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withRecordSeparator(final String recordSeparator) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1896,7 +1922,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withSkipHeaderRecord(final boolean skipHeaderRecord) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1921,7 +1947,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withTrailingDelimiter(final boolean trailingDelimiter) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
 
     /**
@@ -1946,6 +1972,7 @@ public final class CSVFormat implements Serializable {
     public CSVFormat withTrim(final boolean trim) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
                 ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
-                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter);
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, mutableRecords);
     }
+
 }

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -626,7 +626,7 @@ public final class CSVFormat implements Serializable {
      * @param autoFlush
      * 	TODO
      * @param mutableRecords
-     * 	           if {@code true}, return {@link CSVMutableRecord} 
+     * 	           if {@code true}, {@link CSVRecord}s are {@link CSVRecord#mutable()} by default, otherwise immutable 
      * 
      * @throws IllegalArgumentException
      *             if the delimiter is a line break character
@@ -1808,16 +1808,16 @@ public final class CSVFormat implements Serializable {
     }
 
     /**
-     * Returns a new {@code CSVFormat} with whether to generate CSVRecord or CSVMutableRecord.
+     * Returns a new {@code CSVFormat} with mutable or immutable records by default.
      * <ul>
-     * <li><strong>Reading:</strong> Whether to generate CSVRecord or CSVMutableRecord.</li>
+     * <li><strong>Reading:</strong> Mutable by default.</li>
      * <li><strong>Writing:</strong> No effect.</li>
      * </ul>
      *
      * @param mutableRecords
-     *            whether to generate CSVRecord or CSVMutableRecord
+     *            If true, parsed @link CSVRecord}s are {@link CSVRecord#mutable()}, otherwise {@link CSVRecord#immutable()}.
      *
-     * @return A new CSVFormat that is equal to this but with setting to generate CSVRecord or CSVMutableRecord.
+     * @return A new CSVFormat that is equal to this but with setting to generate mutable/immutable records.
      */
     public CSVFormat withMutableRecords(final boolean mutableRecords) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,

--- a/src/main/java/org/apache/commons/csv/CSVMutableRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVMutableRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.csv;
+
+import java.util.Map;
+
+public final class CSVMutableRecord extends CSVRecord {
+
+    private static final long serialVersionUID = 1L;
+
+    CSVMutableRecord(String[] values, Map<String, Integer> mapping, String comment, long recordNumber,
+            long characterPosition) {
+        super(values, mapping, comment, recordNumber, characterPosition);
+    }
+
+    @Override
+    public void put(int index, String value) {
+        super.put(index, value);
+    }
+
+    @Override
+    public void put(String name, String value) {
+        super.put(name, value);
+    }
+
+}

--- a/src/main/java/org/apache/commons/csv/CSVMutableRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVMutableRecord.java
@@ -19,7 +19,19 @@ package org.apache.commons.csv;
 
 import java.util.Map;
 
-public final class CSVMutableRecord extends CSVRecord {
+/**
+ * A mutable version of CSVRecord
+ * <p>
+ * As mutation is generally done within the parent {@link CSVRecord}, this 
+ * package-private class just includes more efficient versions of 
+ * mutator functions, bypassing the need to make copies 
+ * (except in {@link #immutable()}).
+ * <p>
+ * To enable generating CSVMutableRecord by default, set 
+ * {@link CSVFormat#withMutableRecords(boolean)} to <code>true</code>.
+ *
+ */
+final class CSVMutableRecord extends CSVRecord {
 
     private static final long serialVersionUID = 1L;
 
@@ -29,13 +41,25 @@ public final class CSVMutableRecord extends CSVRecord {
     }
 
     @Override
-    public void put(int index, String value) {
-        super.put(index, value);
+    public CSVMutableRecord withValue(int index, String value) {
+    	super.put(index, value);
+    	return this;
     }
-
+    
     @Override
-    public void put(String name, String value) {
-        super.put(name, value);
+    public CSVMutableRecord withValue(String name, String value) {
+    	super.put(name, value);
+    	return this;
     }
-
+    
+    @Override
+    public CSVRecord withComment(String comment) {
+    	this.comment = comment;
+    	return this;
+    }    
+    
+    @Override
+    boolean isMutable() {
+    	return true;
+    }
 }

--- a/src/main/java/org/apache/commons/csv/CSVMutableRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVMutableRecord.java
@@ -41,25 +41,19 @@ final class CSVMutableRecord extends CSVRecord {
     }
 
     @Override
-    public CSVMutableRecord withValue(int index, String value) {
-    	super.put(index, value);
+    public final CSVMutableRecord withValue(int index, String value) {
+    	put(index, value);
     	return this;
     }
     
     @Override
-    public CSVMutableRecord withValue(String name, String value) {
-    	super.put(name, value);
+    public final CSVMutableRecord withValue(String name, String value) {
+    	put(name, value);
     	return this;
     }
     
     @Override
-    public CSVRecord withComment(String comment) {
-    	this.comment = comment;
-    	return this;
-    }    
-    
-    @Override
-    boolean isMutable() {
+    final boolean isMutable() {
     	return true;
     }
 }

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -300,7 +300,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     private final long characterOffset;
 
     private final Token reusableToken = new Token();
-
+    
     /**
      * Customized CSV parser using the given {@link CSVFormat}
      *
@@ -614,8 +614,10 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         if (!this.recordList.isEmpty()) {
             this.recordNumber++;
             final String comment = sb == null ? null : sb.toString();
-            result = new CSVRecord(this.recordList.toArray(new String[this.recordList.size()]), this.headerMap, comment,
-                    this.recordNumber, startCharPosition);
+            String[] array = this.recordList.toArray(new String[this.recordList.size()]);
+            result = format.isMutableRecords()
+                    ? new CSVMutableRecord(array, this.headerMap, comment, this.recordNumber, startCharPosition)
+                    : new CSVRecord(array, this.headerMap, comment, this.recordNumber, startCharPosition);
         }
         return result;
     }

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -199,6 +199,10 @@ public class CSVRecord implements Serializable, Iterable<String> {
     public final CSVRecord immutable() {
     	if (isMutable()) {
 	    	// Subclass is probably CSVMutableRecord, freeze values
+		//
+		// Note: Normally we should not use .clone() as it has many 
+		// issues and pitfalls - here we have an array of immutable Strings
+		// so it's OK.
 		String[] frozenValue = values.clone();
 	    	return new CSVRecord(frozenValue, mapping, comment, recordNumber, characterPosition);
     	} else {
@@ -260,7 +264,10 @@ public class CSVRecord implements Serializable, Iterable<String> {
     	if (isMutable()) {
     		return this;
     	}
-		String[] newValues = values.clone();
+	// Note: Normally we should not use .clone() as it has many 
+	// issues and pitfalls - here we have an array of immutable Strings
+	// so it's OK.
+	String[] newValues = values.clone();
     	return new CSVMutableRecord(newValues, mapping, comment, recordNumber, characterPosition);
 	}    
 

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -28,7 +28,7 @@ import java.util.Map.Entry;
 /**
  * A CSV record parsed from a CSV file.
  */
-public final class CSVRecord implements Serializable, Iterable<String> {
+public class CSVRecord implements Serializable, Iterable<String> {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
@@ -95,20 +95,26 @@ public final class CSVRecord implements Serializable, Iterable<String> {
     public String get(final String name) {
         if (mapping == null) {
             throw new IllegalStateException(
-                "No header mapping was specified, the record values can't be accessed by name");
+                    "No header mapping was specified, the record values can't be accessed by name");
         }
-        final Integer index = mapping.get(name);
-        if (index == null) {
-            throw new IllegalArgumentException(String.format("Mapping for %s not found, expected one of %s", name,
-                mapping.keySet()));
-        }
+        final int intIndex = getIndex(name);
         try {
-            return values[index.intValue()];
+            return values[intIndex];
         } catch (final ArrayIndexOutOfBoundsException e) {
-            throw new IllegalArgumentException(String.format(
-                "Index for header '%s' is %d but CSVRecord only has %d values!", name, index,
-                Integer.valueOf(values.length)));
+            throw new IllegalArgumentException(
+                    String.format("Index for header '%s' is %d but CSVRecord only has %d values!", name, intIndex,
+                            Integer.valueOf(values.length)));
         }
+    }
+
+    int getIndex(final String name) {
+        final Integer integerIndex = mapping.get(name);
+        if (integerIndex == null) {
+            throw new IllegalArgumentException(
+                    String.format("Mapping for %s not found, expected one of %s", name, mapping.keySet()));
+        }
+        int intIndex = integerIndex.intValue();
+        return intIndex;
     }
 
     /**
@@ -207,6 +213,14 @@ public final class CSVRecord implements Serializable, Iterable<String> {
         return toList().iterator();
     }
 
+    void put(final int index, String value) {
+        values[index] = value;
+    }
+
+    void put(final String name, String value) {
+        values[getIndex(name)] = value;
+    }
+    
     /**
      * Puts all values of this record into the given Map.
      *

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -38,9 +38,9 @@ public class CSVRecord implements Serializable, Iterable<String> {
 
     /** The accumulated comments (if any)
      *
-     * package-private so it can be mutated by {@link CSVMutableRecord}
+     * non-final so it can be mutated by {@link CSVMutableRecord}
      */
-    String comment;
+    private String comment;
 
     /** The column name to index mapping. */
     private final Map<String, Integer> mapping;
@@ -67,7 +67,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *            an enum
      * @return the String at the given enum String
      */
-    public String get(final Enum<?> e) {
+    public final String get(final Enum<?> e) {
         return get(e.toString());
     }
 
@@ -78,7 +78,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *            a column index (0-based)
      * @return the String at the given index
      */
-    public String get(final int i) {
+    public final String get(final int i) {
         return values[i];
     }
 
@@ -95,7 +95,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * @see #isConsistent()
      * @see CSVFormat#withNullString(String)
      */
-    public String get(final String name) {
+    public final String get(final String name) {
         if (mapping == null) {
             throw new IllegalStateException(
                     "No header mapping was specified, the record values can't be accessed by name");
@@ -110,7 +110,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
         }
     }
 
-    int getIndex(final String name) {
+    final int getIndex(final String name) {
         final Integer integerIndex = mapping.get(name);
         if (integerIndex == null) {
             throw new IllegalArgumentException(
@@ -126,7 +126,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *
      * @return the position of this record in the source stream.
      */
-    public long getCharacterPosition() {
+    public final long getCharacterPosition() {
         return characterPosition;
     }
 
@@ -138,7 +138,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *
      * @return the comment for this record, or null if no comment for this record is available.
      */
-    public String getComment() {
+    public final String getComment() {
         return comment;
     }
 
@@ -153,7 +153,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * @return the number of this record.
      * @see CSVParser#getCurrentLineNumber()
      */
-    public long getRecordNumber() {
+    public final long getRecordNumber() {
         return recordNumber;
     }
 
@@ -167,7 +167,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *
      * @return true of this record is valid, false if not
      */
-    public boolean isConsistent() {
+    public final boolean isConsistent() {
         return mapping == null || mapping.size() == values.length;
     }
 
@@ -180,7 +180,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * @return true if this record has a comment, false otherwise
      * @since 1.3
      */
-    public boolean hasComment() {
+    public final boolean hasComment() {
         return comment != null;
     }
 
@@ -196,7 +196,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * 
      * @return Am immutable CSVRecord
      */    
-    public CSVRecord immutable() {
+    public final CSVRecord immutable() {
     	if (isMutable()) {
 	    	// Subclass is probably CSVMutableRecord, freeze values
 	    	String[] frozenValue = Arrays.copyOf(values, values.length);
@@ -213,7 +213,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *            the name of the column to be retrieved.
      * @return whether a given column is mapped.
      */
-    public boolean isMapped(final String name) {
+    public final boolean isMapped(final String name) {
         return mapping != null && mapping.containsKey(name);
     }
     
@@ -228,7 +228,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *            the name of the column to be retrieved.
      * @return whether a given columns is mapped and has a value
      */
-    public boolean isSet(final String name) {
+    public final boolean isSet(final String name) {
         return isMapped(name) && mapping.get(name).intValue() < values.length;
     }
 
@@ -238,7 +238,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * @return an iterator over the values of this record.
      */
     @Override
-    public Iterator<String> iterator() {
+    public final Iterator<String> iterator() {
         return toList().iterator();
     }
     
@@ -256,7 +256,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * 
      * @return A mutable CSVRecord
      */
-    public CSVRecord mutable() {
+    public final CSVRecord mutable() {
     	if (isMutable()) {
     		return this;
     	}
@@ -264,11 +264,11 @@ public class CSVRecord implements Serializable, Iterable<String> {
     	return new CSVMutableRecord(newValues, mapping, comment, recordNumber, characterPosition);
 	}    
 
-    void put(final int index, String value) {
+    final void put(final int index, String value) {
         values[index] = value;
     }
 
-    void put(final String name, String value) {
+    final void put(final String name, String value) {
         values[getIndex(name)] = value;
     }
     
@@ -279,7 +279,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *            The Map to populate.
      * @return the given map.
      */
-    <M extends Map<String, String>> M putIn(final M map) {
+    final <M extends Map<String, String>> M putIn(final M map) {
         if (mapping == null) {
             return map;
         }
@@ -297,7 +297,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *
      * @return the number of values.
      */
-    public int size() {
+    public final int size() {
         return values.length;
     }
 
@@ -317,7 +317,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      *
      * @return A new Map. The map is empty if the record has no headers.
      */
-    public Map<String, String> toMap() {
+    public final Map<String, String> toMap() {
         return putIn(new HashMap<String, String>(values.length));
     }
 
@@ -328,13 +328,13 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * @return a String representation of this record.
      */
     @Override
-    public String toString() {
+    public final String toString() {
         return "CSVRecord [comment=" + comment + ", mapping=" + mapping +
                 ", recordNumber=" + recordNumber + ", values=" +
                 Arrays.toString(values) + "]";
     }
 
-    String[] values() {
+    final String[] values() {
         return values;
     }
     
@@ -379,7 +379,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
      * 			the comment to set, or <code>null</code> for no comment.
      * @return A mutated CSVRecord
      */
-    public CSVRecord withComment(String comment) {
+    public final CSVRecord withComment(String comment) {
     	CSVRecord r = mutable();
     	r.comment = comment;
     	return r;

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -199,7 +199,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
     public final CSVRecord immutable() {
     	if (isMutable()) {
 	    	// Subclass is probably CSVMutableRecord, freeze values
-	    	String[] frozenValue = Arrays.copyOf(values, values.length);
+		String[] frozenValue = values.clone();
 	    	return new CSVRecord(frozenValue, mapping, comment, recordNumber, characterPosition);
     	} else {
     		return this;    		
@@ -260,7 +260,7 @@ public class CSVRecord implements Serializable, Iterable<String> {
     	if (isMutable()) {
     		return this;
     	}
-		String[] newValues = Arrays.copyOf(values, values.length);
+		String[] newValues = values.clone();
     	return new CSVMutableRecord(newValues, mapping, comment, recordNumber, characterPosition);
 	}    
 

--- a/src/test/java/org/apache/commons/csv/CSVMutableRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVMutableRecordTest.java
@@ -1,0 +1,32 @@
+package org.apache.commons.csv;
+
+import org.junit.Assert;
+
+public class CSVMutableRecordTest extends CSVRecordTest {
+
+    @Override
+    protected CSVFormat createCommaFormat() {
+        return super.createCommaFormat().withMutableRecords(true);
+    }
+
+    @Override
+    protected CSVFormat createDefaultFormat() {
+        return super.createDefaultFormat().withMutableRecords(true);
+    }
+
+    @Override
+    protected CSVRecord newRecord() {
+        return new CSVMutableRecord(values, null, null, 0, -1);
+    }
+
+    @Override
+    protected CSVRecord newRecordWithHeader() {
+        return new CSVMutableRecord(values, header, null, 0, -1);
+    }
+
+    @Override
+    protected void validate(final CSVRecord anyRecord) {
+        Assert.assertEquals(CSVMutableRecord.class, anyRecord.getClass());
+    }
+
+}

--- a/src/test/java/org/apache/commons/csv/CSVMutableRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVMutableRecordTest.java
@@ -1,8 +1,18 @@
 package org.apache.commons.csv;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Assert;
+import org.junit.Test;
 
 public class CSVMutableRecordTest extends CSVRecordTest {
+
+	@Override
+    @Test
+    public void isMutable() { 
+    	assertTrue(record.isMutable());
+    	assertTrue(recordWithHeader.isMutable());
+    }
 
     @Override
     protected CSVFormat createCommaFormat() {

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -19,7 +19,9 @@ package org.apache.commons.csv;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -187,6 +189,62 @@ public class CSVRecordTest {
         }
     }
 
+    @Test
+    public void isMutable() { 
+    	assertFalse(record.isMutable());
+    	assertFalse(recordWithHeader.isMutable());
+    }
+    
+    @Test
+    public void testMutable() throws Exception {
+    	CSVRecord mutable = record.mutable();
+    	assertTrue(mutable.isMutable());
+    	if (record.isMutable()) { 
+    		assertSame(record, mutable);
+    	} else {    	
+    		assertNotSame(record, mutable);
+    	}    	
+    }
+    
+    @Test
+    public void testImmutable() throws Exception {
+    	CSVRecord immutable = record.immutable();
+    	assertFalse(immutable.isMutable());
+    	assertSame(immutable, immutable.immutable());
+    	assertNotSame(immutable, immutable.mutable());
+    	if (record.isMutable()) { 
+    		assertNotSame(record, immutable);
+    	} else {    	
+    		assertSame(record, immutable);
+    	}
+    }
+    
+    @Test
+    public void testWithValue() throws Exception {
+    	assertEquals("A", record.get(0));
+    	CSVRecord newR = record.withValue(0, "X");
+    	assertEquals("X", newR.get(0));    	
+    	if (record.isMutable()) {
+    		assertSame(record, newR);
+    	} else {
+    		// unchanged
+    		assertEquals("A", record.get(0));
+    	}
+    }
+    
+    @Test
+    public void testWithValueName() throws Exception {
+    	assertEquals("B", recordWithHeader.get("second"));
+    	CSVRecord newR = recordWithHeader.withValue("second", "Y");
+    	assertEquals("Y", newR.get("second"));    	
+    	if (record.isMutable()) {
+    		assertSame(recordWithHeader, newR);
+    	} else {
+    		// unchanged
+    		assertEquals("B", recordWithHeader.get("second"));
+    	}
+    }
+    
     @Test
     public void testToMapWithNoHeader() throws Exception {
         try (final CSVParser parser = CSVParser.parse("a,b", createCommaFormat())) {


### PR DESCRIPTION
Addresses [CSV-215](https://issues.apache.org/jira/browse/CSV-215) and [CSV-216](https://issues.apache.org/jira/browse/CSV-216)

I know mutable `CSVRecord` caused [quite](https://lists.apache.org/thread.html/8f038aac6173d8be63b14c612c6596a613a2c8f0b16de446ea732885@%3Cdev.commons.apache.org%3E) a [discussion](https://lists.apache.org/thread.html/57478abc7f4947e7fe61fe9e46770faf888df156eabdc2fbc6c0c836@%3Cdev.commons.apache.org%3E) earlier.

@garydgregory created a CSV-216 branch b23f963e8dd4ca553a233e653a6220d8e80db9e9 adding a new `CSVMutableRecord` which could be enabled in the format `withMutableRecords(true)`

I like that this means the records remain immutable unless explicitly turned on (hence a `CSVRecord` would be safe to pass around), but I had trouble with this as that required casting to `CSVMutableRecord` to actually mutate.

It is also a bit weird to only be able to mutate a record in the middle of a parsing iterator  - rows are still "immutable".  There is no way to remove/reorder/insert records other than doing it out of bands
(e.g. construct a new List).

This pull request augments the branch to add mutator functions:


```java
for (CSVRecord r : csvparser) {
  CSVRecord rSoup = r.withValue(4, "soup")
                         .withValue(5, "fish");
  // original r is untouched and can be used again
  CSVRecord rBeans = r.withValue(3, "beans");
  someList.add(r);
  someList.add(rSoup);
  someList.add(rBeans);
}
```

By default the records from the parser are immutable (`.isMutable()` return `false`), and the `with` functions create a clones on demand. The mutated records are mutable, but you can force either with `.mutable()` or `.immutable()` -- which would either clone or return itself depending on `isMutable()`.  

Setting `.withMutableRecords(true)` in the format can be used to avoid the initial array clone of `.withValue`.

The subclass `CSVMutableRecord` is now package-private and just short-circuits some of the above, as the mutator functions are always available.

For completeness I added `.withComment()` -- but I'm not sure about the current approach here as it means I have to make `CSVRecord.comment` non-final and package-accessible to `CSVMutableRecord` (or it would have to keep a duplicate `comment` field and override all the comment methods)

(This would have been easier if `CSVRecord` was an interface and we could avoid subclassing.)

