### PR TITLE
CSV-223 Inconsistency between Javadoc of CSVFormat DEFAULT EXCEL

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -268,7 +268,7 @@ public final class CSVFormat implements Serializable {
      * </ul>
      * <p>
      * Note: this is currently like {@link #RFC4180} plus {@link #withAllowMissingColumnNames(boolean)
-     * withAllowMissingColumnNames(true)}.
+     * withAllowMissingColumnNames(true)} and {@link #withIgnoreEmptyLines(boolean) withIgnoreEmptyLines(false)}.
      * </p>
      *
      * @see Predefined#Excel


### PR DESCRIPTION
Javadoc amended, addressing https://issues.apache.org/jira/browse/CSV-223