### PR TITLE
Performance Enhancement: Call toArray with Zero Array Size

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -620,7 +620,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         if (!this.recordList.isEmpty()) {
             this.recordNumber++;
             final String comment = sb == null ? null : sb.toString();
-            result = new CSVRecord(this.recordList.toArray(new String[this.recordList.size()]), this.headerMap, comment,
+            result = new CSVRecord(this.recordList.toArray(new String[0]), this.headerMap, comment,
                     this.recordNumber, startCharPosition);
         }
         return result;


### PR DESCRIPTION
toArray should, at least since Java 7, be used with new T[0] instead of size, since it is "faster, safer, and contractually cleaner" (https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_conclusion)