### PR TITLE
Turn CSVRecord into a List

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -42,6 +42,7 @@
       <action issue="CSV-233" type="add" dev="ggregory" due-to="Gary Gregory">Add predefined CSVFormats for printing MongoDB CSV and TSV.</action>
       <action issue="CSV-208" type="fix" dev="ggregory" due-to="Jurrie Overgoor">Fix escape character for POSTGRESQL_TEXT and POSTGRESQL_CSV formats.</action>
       <action issue="CSV-232" type="fix" dev="ggregory" due-to="Jurrie Overgoor, Gary Gregory">Site link "Source Repository" does not work.</action>
+      <action type="add" dev="mina86" due-to="Michal Nazarewicz">Turn CSVRecord into a List.</action>
     </release>
     <release version="1.6" date="2018-09-22" description="Feature and bug fix release">
       <action issue="CSV-231" type="update" dev="britter">Add more documentation to CSVPrinter.</action>

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -18,6 +18,7 @@
 package org.apache.commons.csv;
 
 import java.io.Serializable;
+import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,7 +29,7 @@ import java.util.Map.Entry;
 /**
  * A CSV record parsed from a CSV file.
  */
-public final class CSVRecord implements Serializable, Iterable<String> {
+public final class CSVRecord extends AbstractList<String> implements Serializable {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
@@ -75,6 +76,7 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      *            a column index (0-based)
      * @return the String at the given index
      */
+    @Override
     public String get(final int i) {
         return values[i];
     }
@@ -198,16 +200,6 @@ public final class CSVRecord implements Serializable, Iterable<String> {
     }
 
     /**
-     * Returns an iterator over the values of this record.
-     *
-     * @return an iterator over the values of this record.
-     */
-    @Override
-    public Iterator<String> iterator() {
-        return toList().iterator();
-    }
-
-    /**
      * Puts all values of this record into the given Map.
      *
      * @param map
@@ -232,19 +224,9 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      *
      * @return the number of values.
      */
+    @Override
     public int size() {
         return values.length;
-    }
-
-    /**
-     * Converts the values to a List.
-     *
-     * TODO: Maybe make this public?
-     *
-     * @return a new List
-     */
-    private List<String> toList() {
-        return Arrays.asList(values);
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -28,6 +28,10 @@ import java.util.Map.Entry;
 
 /**
  * A CSV record parsed from a CSV file.
+ *
+ * <p>The class implements {@link List} interface but does not allow
+ * modifications, i.e. all destructive operations (such as {@link List#add} or
+ * even {@link List#set}) throw {@link UnsupportedOperationException}.
  */
 public final class CSVRecord extends AbstractList<String> implements Serializable {
 

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 public class CSVRecordTest {
 
-    private enum EnumFixture { UNKNOWN_COLUMN }
+    private enum EnumFixture { first, second, third, UNKNOWN_COLUMN }
 
     private String[] values;
     private CSVRecord record, recordWithHeader;
@@ -65,6 +65,13 @@ public class CSVRecordTest {
         assertEquals(values[0], recordWithHeader.get("first"));
         assertEquals(values[1], recordWithHeader.get("second"));
         assertEquals(values[2], recordWithHeader.get("third"));
+    }
+
+    @Test
+    public void testGetEnum() {
+        assertEquals(values[0], recordWithHeader.get(EnumFixture.first));
+        assertEquals(values[1], recordWithHeader.get(EnumFixture.second));
+        assertEquals(values[2], recordWithHeader.get(EnumFixture.third));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -193,4 +200,8 @@ public class CSVRecordTest {
         assertEquals(null, map.get("fourth"));
     }
 
+    @Test
+    public void testToString() {
+        assertEquals("CSVRecord [comment=null, mapping=null, recordNumber=0, values=[A, B, C]]", record.toString());
+    }
 }


### PR DESCRIPTION
CSVRecord implements get(int) and size() methods so it’s already pretty
much a list.  However, because it does not implement the List interface,
users cannot take advantage of convenience methods such as subList nor
can they pass records around to methods accepting lists.

Make CSVRecord extend AbstractList so that it implements List interface.

Because AbstractList pravides iterator() implementation, this allows us
to delete said method (alongside toList() method) reducing amount of
code.