### PR TITLE
[CSV-238] Escape quotes in CLOBs

### DIFF
--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -219,8 +219,11 @@ public class CSVPrinterTest {
         try (final Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255), TEXT CLOB)");
             statement.execute("insert into TEST values(1, 'r1', 'long text 1')");
-            longText2 = StringUtils.repeat('a', (IOUtils.DEFAULT_BUFFER_SIZE * 2) + 1);
+            longText2 = StringUtils.repeat('a', IOUtils.DEFAULT_BUFFER_SIZE - 4);
+            longText2 += "\"\r\n\"a\"";
+            longText2 += StringUtils.repeat('a', IOUtils.DEFAULT_BUFFER_SIZE - 1);
             statement.execute("insert into TEST values(2, 'r2', '" + longText2 + "')");
+            longText2 = longText2.replace("\"","\"\"");
         }
     }
 


### PR DESCRIPTION
(The bad coveralls report is from code merged to master this last weekend, not this patch)

This fixes Excel output by enabling the escaping of quotes in CLOBs.

Given a CLOB like:
```
Choose either
"Y" or "N"
```
The patch will transform it to:
```
Choose either
""Y"" or ""N""
```