### PR TITLE
CSVFormat#valiadte() does not account for allowDuplicateHeaderNames

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -1668,7 +1668,7 @@ public final class CSVFormat implements Serializable {
         }
 
         // validate header
-        if (header != null) {
+        if (header != null && !allowDuplicateHeaderNames){
             final Set<String> dupCheck = new HashSet<>();
             for (final String hdr : header) {
                 if (!dupCheck.add(hdr)) {

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -72,8 +72,18 @@ public class CSVFormatTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testDuplicateHeaderElementsThrowsException() {
+        CSVFormat.DEFAULT.withHeader("A", "A").withAllowDuplicateHeaderNames(false);
+    }
+
+    @Test
     public void testDuplicateHeaderElements() {
-        CSVFormat.DEFAULT.withHeader("A", "A");
+        String[] header = {"A", "A"};
+
+        CSVFormat format = CSVFormat.DEFAULT.withHeader(header);
+
+        assertEquals(2, format.getHeader().length);
+        assertEquals(header, format.getHeader());
     }
 
     @Test


### PR DESCRIPTION
disabled duplicate check when duplicate header name is allowed