### PR TITLE
CSV-247: CSVParser to check an empty header before checking duplicates.

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -495,19 +495,18 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
             if (headerRecord != null) {
                 for (int i = 0; i < headerRecord.length; i++) {
                     final String header = headerRecord[i];
-                    final boolean containsHeader = header != null && hdrMap.containsKey(header);
                     final boolean emptyHeader = header == null || header.trim().isEmpty();
-                    if (containsHeader) {
-                        if (!emptyHeader && !this.format.getAllowDuplicateHeaderNames()) {
-                            throw new IllegalArgumentException(
-                                String.format(
-                                    "The header contains a duplicate name: \"%s\" in %s. If this is valid then use CSVFormat.withAllowDuplicateHeaderNames().",
-                                    header, Arrays.toString(headerRecord)));
-                        }
-                        if (emptyHeader && !this.format.getAllowMissingColumnNames()) {
-                            throw new IllegalArgumentException(
-                                    "A header name is missing in " + Arrays.toString(headerRecord));
-                        }
+                    if (emptyHeader && !this.format.getAllowMissingColumnNames()) {
+                        throw new IllegalArgumentException(
+                            "A header name is missing in " + Arrays.toString(headerRecord));
+                    }
+                    // Note: This will always allow a duplicate header if the header is empty
+                    final boolean containsHeader = header != null && hdrMap.containsKey(header);
+                    if (containsHeader && !emptyHeader && !this.format.getAllowDuplicateHeaderNames()) {
+                        throw new IllegalArgumentException(
+                            String.format(
+                                "The header contains a duplicate name: \"%s\" in %s. If this is valid then use CSVFormat.withAllowDuplicateHeaderNames().",
+                                header, Arrays.toString(headerRecord)));
                     }
                     if (header != null) {
                         hdrMap.put(header, Integer.valueOf(i));

--- a/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -19,5 +19,5 @@
     "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
     "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
-  <suppress checks="LineLength" files="[\\/]CSVParser\.java$" lines="504"/>
+  <suppress checks="LineLength" files="[\\/]CSVParser\.java$" lines="508"/>
 </suppressions>

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -688,7 +688,7 @@ public class CSVParserTest {
     public void testHeaderMissing() throws Exception {
         final Reader in = new StringReader("a,,c\n1,2,3\nx,y,z");
 
-        final Iterator<CSVRecord> records = CSVFormat.DEFAULT.withHeader().parse(in).iterator();
+        final Iterator<CSVRecord> records = CSVFormat.DEFAULT.withHeader().withAllowMissingColumnNames().parse(in).iterator();
 
         for (int i = 0; i < 2; i++) {
             assertTrue(records.hasNext());
@@ -702,20 +702,26 @@ public class CSVParserTest {
 
     @Test
     public void testHeaderMissingWithNull() throws Exception {
-        final Reader in = new StringReader("a,,c,,d\n1,2,3,4\nx,y,z,zz");
+        final Reader in = new StringReader("a,,c,,e\n1,2,3,4,5\nv,w,x,y,z");
         CSVFormat.DEFAULT.withHeader().withNullString("").withAllowMissingColumnNames().parse(in).iterator();
     }
 
     @Test
     public void testHeadersMissing() throws Exception {
-        final Reader in = new StringReader("a,,c,,d\n1,2,3,4\nx,y,z,zz");
+        final Reader in = new StringReader("a,,c,,e\n1,2,3,4,5\nv,w,x,y,z");
         CSVFormat.DEFAULT.withHeader().withAllowMissingColumnNames().parse(in).iterator();
     }
 
     @Test
     public void testHeadersMissingException() {
-        final Reader in = new StringReader("a,,c,,d\n1,2,3,4\nx,y,z,zz");
+        final Reader in = new StringReader("a,,c,,e\n1,2,3,4,5\nv,w,x,y,z");
         assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withHeader().parse(in).iterator());
+    }
+
+    @Test
+    public void testHeadersMissingOneColumnException() throws Exception {
+       final Reader in = new StringReader("a,,c,d,e\n1,2,3,4,5\nv,w,x,y,z");
+       assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withHeader().parse(in).iterator());
     }
 
     @Test


### PR DESCRIPTION
This rearranges the logic of checking for empty column headers before checking for duplicates.

I've left the rest of the logic alone. The implication is that it will always allow a duplicate header if the header is empty irrespective of whether duplicates are not allowed. So you can configure the parser to not allow duplicates but allow missing headers and then it skips the fact that each missing header is a duplicate. If documented this in the code.

I also note that the header is checked for a duplicate without trim but the empty header check uses trim. This is contradictory but perhaps a user does want to have headers `"A"," A "," A"`. Any proper CSV header would not whitespace pad headers so I'll leave this until someone reports it as a problem. 

The fix found that the existing test `CSVParserTest.testHeaderMissing()` did not set the AllowMissingColumnNames property. If this test is to work with a missing header then it needs that setting.

I also updated the tests of missing headers which use 5 columns to have 5 entries in the record. Previously it was 4 which is not correct.
