### PR TITLE
CSV-252: Migration to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@ CSV files of various types.
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>3.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,15 @@ CSV files of various types.
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.5.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/commons/csv/AssertionsTest.java
+++ b/src/test/java/org/apache/commons/csv/AssertionsTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.commons.csv;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -28,8 +30,8 @@ public class AssertionsTest {
         Assertions.notNull(new Object(), "object");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNotNullNull() throws Exception {
-        Assertions.notNull(null, "object");
+    @Test
+    public void testNotNullNull() {
+        assertThrows(IllegalArgumentException.class, () -> Assertions.notNull(null, "object"));
     }
 }

--- a/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
@@ -17,152 +17,138 @@
 
 package org.apache.commons.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Parse tests using test files
  */
-@RunWith(Parameterized.class)
 public class CSVFileParserTest {
 
     private static final File BASE = new File("src/test/resources/CSVFileParser");
 
-    private final BufferedReader testData;
-
-    private final String testName;
-
-    public CSVFileParserTest(final File file) throws FileNotFoundException {
-        this.testName = file.getName();
-        this.testData = new BufferedReader(new FileReader(file));
-    }
-
-    private String readTestData() throws IOException {
+    private String readTestData(BufferedReader reader) throws IOException {
         String line;
         do {
-            line = testData.readLine();
+            line = reader.readLine();
         } while (line != null && line.startsWith("#"));
         return line;
     }
 
-    @Parameters
-    public static Collection<Object[]> generateData() {
-        final List<Object[]> list = new ArrayList<>();
-
+    public static Stream<File> generateData() {
         final FilenameFilter fileNameFilter = (dir, name) -> name.startsWith("test") && name.endsWith(".txt");
         final File[] files = BASE.listFiles(fileNameFilter);
         if (files != null) {
-            for (final File f : files) {
-                list.add(new Object[] { f });
-            }
+            return Arrays.stream(files);
         }
-        return list;
+        return Stream.empty();
     }
 
-    @Test
-    public void testCSVFile() throws Exception {
-        String line = readTestData();
-        assertNotNull("file must contain config line", line);
-        final String[] split = line.split(" ");
-        assertTrue(testName + " require 1 param", split.length >= 1);
-        // first line starts with csv data file name
-        CSVFormat format = CSVFormat.newFormat(',').withQuote('"');
-        boolean checkComments = false;
-        for (int i = 1; i < split.length; i++) {
-            final String option = split[i];
-            final String[] option_parts = option.split("=", 2);
-            if ("IgnoreEmpty".equalsIgnoreCase(option_parts[0])) {
-                format = format.withIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1]));
-            } else if ("IgnoreSpaces".equalsIgnoreCase(option_parts[0])) {
-                format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1]));
-            } else if ("CommentStart".equalsIgnoreCase(option_parts[0])) {
-                format = format.withCommentMarker(option_parts[1].charAt(0));
-            } else if ("CheckComments".equalsIgnoreCase(option_parts[0])) {
-                checkComments = true;
-            } else {
-                fail(testName + " unexpected option: " + option);
-            }
-        }
-        line = readTestData(); // get string version of format
-        assertEquals(testName + " Expected format ", line, format.toString());
-
-        // Now parse the file and compare against the expected results
-        // We use a buffered reader internally so no need to create one here.
-        try (final CSVParser parser = CSVParser.parse(new File(BASE, split[0]), Charset.defaultCharset(), format)) {
-            for (final CSVRecord record : parser) {
-                String parsed = Arrays.toString(record.values());
-                if (checkComments) {
-                    final String comment = record.getComment().replace("\n", "\\n");
-                    if (comment != null) {
-                        parsed += "#" + comment;
-                    }
+    @ParameterizedTest
+    @MethodSource("generateData")
+    public void testCSVFile(File testFile) throws Exception {
+        try (FileReader fr = new FileReader(testFile); BufferedReader testData = new BufferedReader(fr)) {
+            String line = readTestData(testData);
+            assertNotNull("file must contain config line", line);
+            final String[] split = line.split(" ");
+            assertTrue(split.length >= 1, testFile.getName() + " require 1 param");
+            // first line starts with csv data file name
+            CSVFormat format = CSVFormat.newFormat(',').withQuote('"');
+            boolean checkComments = false;
+            for (int i = 1; i < split.length; i++) {
+                final String option = split[i];
+                final String[] option_parts = option.split("=", 2);
+                if ("IgnoreEmpty".equalsIgnoreCase(option_parts[0])) {
+                    format = format.withIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1]));
+                } else if ("IgnoreSpaces".equalsIgnoreCase(option_parts[0])) {
+                    format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1]));
+                } else if ("CommentStart".equalsIgnoreCase(option_parts[0])) {
+                    format = format.withCommentMarker(option_parts[1].charAt(0));
+                } else if ("CheckComments".equalsIgnoreCase(option_parts[0])) {
+                    checkComments = true;
+                } else {
+                    fail(testFile.getName() + " unexpected option: " + option);
                 }
-                final int count = record.size();
-                assertEquals(testName, readTestData(), count + ":" + parsed);
+            }
+            line = readTestData(testData); // get string version of format
+            assertEquals(line, format.toString(), testFile.getName() + " Expected format ");
+
+            // Now parse the file and compare against the expected results
+            // We use a buffered reader internally so no need to create one here.
+            try (final CSVParser parser = CSVParser.parse(new File(BASE, split[0]), Charset.defaultCharset(), format)) {
+                for (final CSVRecord record : parser) {
+                    String parsed = Arrays.toString(record.values());
+                    if (checkComments) {
+                        final String comment = record.getComment().replace("\n", "\\n");
+                        if (comment != null) {
+                            parsed += "#" + comment;
+                        }
+                    }
+                    final int count = record.size();
+                    assertEquals(readTestData(testData), count + ":" + parsed, testFile.getName());
+                }
             }
         }
     }
 
-    @Test
-    public void testCSVUrl() throws Exception {
-        String line = readTestData();
-        assertNotNull("file must contain config line", line);
-        final String[] split = line.split(" ");
-        assertTrue(testName + " require 1 param", split.length >= 1);
-        // first line starts with csv data file name
-        CSVFormat format = CSVFormat.newFormat(',').withQuote('"');
-        boolean checkComments = false;
-        for (int i = 1; i < split.length; i++) {
-            final String option = split[i];
-            final String[] option_parts = option.split("=", 2);
-            if ("IgnoreEmpty".equalsIgnoreCase(option_parts[0])) {
-                format = format.withIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1]));
-            } else if ("IgnoreSpaces".equalsIgnoreCase(option_parts[0])) {
-                format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1]));
-            } else if ("CommentStart".equalsIgnoreCase(option_parts[0])) {
-                format = format.withCommentMarker(option_parts[1].charAt(0));
-            } else if ("CheckComments".equalsIgnoreCase(option_parts[0])) {
-                checkComments = true;
-            } else {
-                fail(testName + " unexpected option: " + option);
-            }
-        }
-        line = readTestData(); // get string version of format
-        assertEquals(testName + " Expected format ", line, format.toString());
-
-        // Now parse the file and compare against the expected results
-        final URL resource = ClassLoader.getSystemResource("CSVFileParser/" + split[0]);
-        try (final CSVParser parser = CSVParser.parse(resource, Charset.forName("UTF-8"), format)) {
-            for (final CSVRecord record : parser) {
-                String parsed = Arrays.toString(record.values());
-                if (checkComments) {
-                    final String comment = record.getComment().replace("\n", "\\n");
-                    if (comment != null) {
-                        parsed += "#" + comment;
-                    }
+    @ParameterizedTest
+    @MethodSource("generateData")
+    public void testCSVUrl(File testFile) throws Exception {
+        try (FileReader fr = new FileReader(testFile); BufferedReader testData = new BufferedReader(fr)) {
+            String line = readTestData(testData);
+            assertNotNull("file must contain config line", line);
+            final String[] split = line.split(" ");
+            assertTrue(split.length >= 1, testFile.getName() + " require 1 param");
+            // first line starts with csv data file name
+            CSVFormat format = CSVFormat.newFormat(',').withQuote('"');
+            boolean checkComments = false;
+            for (int i = 1; i < split.length; i++) {
+                final String option = split[i];
+                final String[] option_parts = option.split("=", 2);
+                if ("IgnoreEmpty".equalsIgnoreCase(option_parts[0])) {
+                    format = format.withIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1]));
+                } else if ("IgnoreSpaces".equalsIgnoreCase(option_parts[0])) {
+                    format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1]));
+                } else if ("CommentStart".equalsIgnoreCase(option_parts[0])) {
+                    format = format.withCommentMarker(option_parts[1].charAt(0));
+                } else if ("CheckComments".equalsIgnoreCase(option_parts[0])) {
+                    checkComments = true;
+                } else {
+                    fail(testFile.getName() + " unexpected option: " + option);
                 }
-                final int count = record.size();
-                assertEquals(testName, readTestData(), count + ":" + parsed);
+            }
+            line = readTestData(testData); // get string version of format
+            assertEquals(line, format.toString(), testFile.getName() + " Expected format ");
+
+            // Now parse the file and compare against the expected results
+            final URL resource = ClassLoader.getSystemResource("CSVFileParser/" + split[0]);
+            try (final CSVParser parser = CSVParser.parse(resource, Charset.forName("UTF-8"), format)) {
+                for (final CSVRecord record : parser) {
+                    String parsed = Arrays.toString(record.values());
+                    if (checkComments) {
+                        final String comment = record.getComment().replace("\n", "\\n");
+                        if (comment != null) {
+                            parsed += "#" + comment;
+                        }
+                    }
+                    final int count = record.size();
+                    assertEquals(readTestData(testData), count + ":" + parsed, testFile.getName());
+                }
             }
         }
     }

--- a/src/test/java/org/apache/commons/csv/CSVFormatPredefinedTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatPredefinedTest.java
@@ -17,7 +17,8 @@
 
 package org.apache.commons.csv;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 /**
@@ -26,8 +27,8 @@ import org.junit.Test;
 public class CSVFormatPredefinedTest {
 
     private void test(final CSVFormat format, final String enumName) {
-        Assert.assertEquals(format, CSVFormat.Predefined.valueOf(enumName).getFormat());
-        Assert.assertEquals(format, CSVFormat.valueOf(enumName));
+        assertEquals(format, CSVFormat.Predefined.valueOf(enumName).getFormat());
+        assertEquals(format, CSVFormat.valueOf(enumName));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/csv/CSVFormatPredefinedTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatPredefinedTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.csv;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link CSVFormat.Predefined}.

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.csv;
 
-import static junit.framework.TestCase.assertNull;
 import static org.apache.commons.csv.CSVFormat.RFC4180;
 import static org.apache.commons.csv.Constants.CR;
 import static org.apache.commons.csv.Constants.CRLF;
@@ -27,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -21,14 +21,16 @@ import static org.apache.commons.csv.CSVFormat.RFC4180;
 import static org.apache.commons.csv.Constants.CR;
 import static org.apache.commons.csv.Constants.CRLF;
 import static org.apache.commons.csv.Constants.LF;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,7 +40,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link CSVFormat}.
@@ -71,14 +73,14 @@ public class CSVFormatTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDelimiterSameAsCommentStartThrowsException() {
-        CSVFormat.DEFAULT.withDelimiter('!').withCommentMarker('!');
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter('!').withCommentMarker('!'));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDelimiterSameAsEscapeThrowsException() {
-        CSVFormat.DEFAULT.withDelimiter('!').withEscape('!');
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter('!').withEscape('!'));
     }
 
     @Test
@@ -89,9 +91,11 @@ public class CSVFormatTest {
         assertArrayEquals(header, format.getHeader());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDuplicateHeaderElementsFalse() {
-        CSVFormat.DEFAULT.withAllowDuplicateHeaderNames(false).withHeader("A", "A");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVFormat.DEFAULT.withAllowDuplicateHeaderNames(false).withHeader("A", "A"));
     }
 
     public void testDuplicateHeaderElementsTrue() {
@@ -519,15 +523,17 @@ public class CSVFormatTest {
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEscapeSameAsCommentStartThrowsException() {
-        CSVFormat.DEFAULT.withEscape('!').withCommentMarker('!');
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withEscape('!').withCommentMarker('!'));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEscapeSameAsCommentStartThrowsExceptionForWrapperType() {
         // Cannot assume that callers won't use different Character objects
-        CSVFormat.DEFAULT.withEscape(new Character('!')).withCommentMarker(new Character('!'));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVFormat.DEFAULT.withEscape(new Character('!')).withCommentMarker(new Character('!')));
     }
 
     @Test
@@ -658,25 +664,27 @@ public class CSVFormatTest {
         assertFalse(formatStr.endsWith("null"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testQuoteCharSameAsCommentStartThrowsException() {
-        CSVFormat.DEFAULT.withQuote('!').withCommentMarker('!');
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withQuote('!').withCommentMarker('!'));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testQuoteCharSameAsCommentStartThrowsExceptionForWrapperType() {
         // Cannot assume that callers won't use different Character objects
-        CSVFormat.DEFAULT.withQuote(new Character('!')).withCommentMarker('!');
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVFormat.DEFAULT.withQuote(new Character('!')).withCommentMarker('!'));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testQuoteCharSameAsDelimiterThrowsException() {
-        CSVFormat.DEFAULT.withQuote('!').withDelimiter('!');
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withQuote('!').withDelimiter('!'));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testQuotePolicyNoneWithoutEscapeThrowsException() {
-        CSVFormat.newFormat('!').withQuoteMode(QuoteMode.NONE);
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.newFormat('!').withQuoteMode(QuoteMode.NONE));
     }
 
     @Test
@@ -704,13 +712,13 @@ public class CSVFormatTest {
         final CSVFormat format = (CSVFormat) in.readObject();
 
         assertNotNull(format);
-        assertEquals("delimiter", CSVFormat.DEFAULT.getDelimiter(), format.getDelimiter());
-        assertEquals("encapsulator", CSVFormat.DEFAULT.getQuoteCharacter(), format.getQuoteCharacter());
-        assertEquals("comment start", CSVFormat.DEFAULT.getCommentMarker(), format.getCommentMarker());
-        assertEquals("record separator", CSVFormat.DEFAULT.getRecordSeparator(), format.getRecordSeparator());
-        assertEquals("escape", CSVFormat.DEFAULT.getEscapeCharacter(), format.getEscapeCharacter());
-        assertEquals("trim", CSVFormat.DEFAULT.getIgnoreSurroundingSpaces(), format.getIgnoreSurroundingSpaces());
-        assertEquals("empty lines", CSVFormat.DEFAULT.getIgnoreEmptyLines(), format.getIgnoreEmptyLines());
+        assertEquals(CSVFormat.DEFAULT.getDelimiter(), format.getDelimiter(), "delimiter");
+        assertEquals(CSVFormat.DEFAULT.getQuoteCharacter(), format.getQuoteCharacter(), "encapsulator");
+        assertEquals(CSVFormat.DEFAULT.getCommentMarker(), format.getCommentMarker(), "comment start");
+        assertEquals(CSVFormat.DEFAULT.getRecordSeparator(), format.getRecordSeparator(), "record separator");
+        assertEquals(CSVFormat.DEFAULT.getEscapeCharacter(), format.getEscapeCharacter(), "escape");
+        assertEquals(CSVFormat.DEFAULT.getIgnoreSurroundingSpaces(), format.getIgnoreSurroundingSpaces(), "trim");
+        assertEquals(CSVFormat.DEFAULT.getIgnoreEmptyLines(), format.getIgnoreEmptyLines(), "empty lines");
     }
 
     @Test
@@ -890,9 +898,9 @@ public class CSVFormatTest {
         assertEquals( Character.valueOf('#'), formatWithCommentStart.getCommentMarker());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithCommentStartCRThrowsException() {
-        CSVFormat.DEFAULT.withCommentMarker(CR);
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withCommentMarker(CR));
     }
 
     @Test
@@ -901,9 +909,9 @@ public class CSVFormatTest {
         assertEquals('!', formatWithDelimiter.getDelimiter());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithDelimiterLFThrowsException() {
-        CSVFormat.DEFAULT.withDelimiter(LF);
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter(LF));
     }
 
     @Test
@@ -918,9 +926,9 @@ public class CSVFormatTest {
         assertEquals(Character.valueOf('&'), formatWithEscape.getEscapeCharacter());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithEscapeCRThrowsExceptions() {
-        CSVFormat.DEFAULT.withEscape(CR);
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withEscape(CR));
     }
 
     @Test
@@ -1137,9 +1145,9 @@ public class CSVFormatTest {
     }
 
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithQuoteLFThrowsException() {
-        CSVFormat.DEFAULT.withQuote(LF);
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withQuote(LF));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -38,7 +38,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -910,7 +909,7 @@ public class CSVFormatTest {
     @Test
     public void testWithEmptyEnum() throws Exception {
         final CSVFormat formatWithHeader = CSVFormat.DEFAULT.withHeader(EmptyEnum.class);
-        Assert.assertTrue(formatWithHeader.getHeader().length == 0);
+        assertTrue(formatWithHeader.getHeader().length == 0);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.io.input.BOMInputStream;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -85,7 +84,7 @@ public class CSVParserTest {
 
     private void parseFully(final CSVParser parser) {
         for (final CSVRecord csvRecord : parser) {
-            Assert.assertNotNull(csvRecord);
+            assertNotNull(csvRecord);
         }
     }
 
@@ -183,7 +182,7 @@ public class CSVParserTest {
         try (final CSVParser parser = CSVParser.parse(url, Charset.forName(UTF_8_NAME), CSVFormat.EXCEL.withHeader())) {
             for (final CSVRecord record : parser) {
                 final String string = record.get("Date");
-                Assert.assertNotNull(string);
+                assertNotNull(string);
                 // System.out.println("date: " + record.get("Date"));
             }
         }
@@ -195,7 +194,7 @@ public class CSVParserTest {
                 final CSVParser parser = CSVParser.parse(inputStream, UTF_8, CSVFormat.EXCEL.withHeader())) {
             for (final CSVRecord record : parser) {
                 final String string = record.get("Date");
-                Assert.assertNotNull(string);
+                assertNotNull(string);
                 // System.out.println("date: " + record.get("Date"));
             }
         }
@@ -207,7 +206,7 @@ public class CSVParserTest {
                 final CSVParser parser = new CSVParser(reader, CSVFormat.EXCEL.withHeader())) {
             for (final CSVRecord record : parser) {
                 final String string = record.get("Date");
-                Assert.assertNotNull(string);
+                assertNotNull(string);
                 // System.out.println("date: " + record.get("Date"));
             }
         }
@@ -219,7 +218,7 @@ public class CSVParserTest {
                 final CSVParser parser = CSVParser.parse(reader, CSVFormat.EXCEL.withHeader())) {
             for (final CSVRecord record : parser) {
                 final String string = record.get("Date");
-                Assert.assertNotNull(string);
+                assertNotNull(string);
                 // System.out.println("date: " + record.get("Date"));
             }
         }
@@ -430,9 +429,9 @@ public class CSVParserTest {
         final String code = "A,B,C,,\r\na,b,c,d,e\r\n";
         try (final CSVParser parser = CSVParser.parse(code, CSVFormat.EXCEL.withHeader())) {
             for (final CSVRecord record : parser.getRecords()) {
-                Assert.assertEquals("a", record.get("A"));
-                Assert.assertEquals("b", record.get("B"));
-                Assert.assertEquals("c", record.get("C"));
+                assertEquals("a", record.get("A"));
+                assertEquals("b", record.get("B"));
+                assertEquals("c", record.get("C"));
             }
         }
     }
@@ -488,9 +487,9 @@ public class CSVParserTest {
             final Map<String, Integer> headerMap = parser.getHeaderMap();
             final Iterator<String> columnNames = headerMap.keySet().iterator();
             // Headers are iterated in column order.
-            Assert.assertEquals("A", columnNames.next());
-            Assert.assertEquals("B", columnNames.next());
-            Assert.assertEquals("C", columnNames.next());
+            assertEquals("A", columnNames.next());
+            assertEquals("B", columnNames.next());
+            assertEquals("C", columnNames.next());
             final Iterator<CSVRecord> records = parser.iterator();
 
             // Parse to make sure getHeaderMap did not have a side-effect.
@@ -512,11 +511,11 @@ public class CSVParserTest {
             CSVFormat.DEFAULT.withHeader("A", "B", "C"))) {
             final Map<String, Integer> nameIndexMap = parser.getHeaderMap();
             final List<String> headerNames = parser.getHeaderNames();
-            Assert.assertNotNull(headerNames);
-            Assert.assertEquals(nameIndexMap.size(), headerNames.size());
+            assertNotNull(headerNames);
+            assertEquals(nameIndexMap.size(), headerNames.size());
             for (int i = 0; i < headerNames.size(); i++) {
                 final String name = headerNames.get(i);
-                Assert.assertEquals(i, nameIndexMap.get(name).intValue());
+                assertEquals(i, nameIndexMap.get(name).intValue());
             }
         }
     }
@@ -526,7 +525,7 @@ public class CSVParserTest {
         try (final CSVParser parser = CSVParser.parse("a,b,c\n1,2,3\nx,y,z",
             CSVFormat.DEFAULT.withHeader("A", "B", "C"))) {
             final List<String> headerNames = parser.getHeaderNames();
-            Assert.assertNotNull(headerNames);
+            assertNotNull(headerNames);
             try {
                 headerNames.add("This is a read-only list.");
                 fail();
@@ -748,7 +747,7 @@ public class CSVParserTest {
     public void testInvalidFormat() throws Exception {
         final CSVFormat invalidFormat = CSVFormat.DEFAULT.withDelimiter(CR);
         try (final CSVParser parser = new CSVParser(null, invalidFormat)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
@@ -924,21 +923,21 @@ public class CSVParserTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNewCSVParserNullReaderFormat() throws Exception {
         try (final CSVParser parser = new CSVParser(null, CSVFormat.DEFAULT)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNewCSVParserReaderNullFormat() throws Exception {
         try (final CSVParser parser = new CSVParser(new StringReader(""), null)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test
     public void testNoHeaderMap() throws Exception {
         try (final CSVParser parser = CSVParser.parse("a,b,c\n1,2,3\nx,y,z", CSVFormat.DEFAULT)) {
-            Assert.assertNull(parser.getHeaderMap());
+            assertNull(parser.getHeaderMap());
         }
     }
 
@@ -978,56 +977,56 @@ public class CSVParserTest {
     @Test(expected = IllegalArgumentException.class)
     public void testParseFileNullFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse(new File("CSVFileParser/test.csv"), Charset.defaultCharset(), null)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testParseNullFileFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse((File) null, Charset.defaultCharset(), CSVFormat.DEFAULT)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testParseNullPathFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse((Path) null, Charset.defaultCharset(), CSVFormat.DEFAULT)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testParseNullStringFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse((String) null, CSVFormat.DEFAULT)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testParseNullUrlCharsetFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse((URL) null, Charset.defaultCharset(), CSVFormat.DEFAULT)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testParserUrlNullCharsetFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse(new URL("https://commons.apache.org"), null, CSVFormat.DEFAULT)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testParseStringNullFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse("csv data", (CSVFormat) null)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testParseUrlCharsetNullFormat() throws Exception {
         try (final CSVParser parser = CSVParser.parse(new URL("https://commons.apache.org"), Charset.defaultCharset(), null)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
@@ -1156,7 +1155,7 @@ public class CSVParserTest {
         assertEquals("1", record.get("X"));
         assertEquals("2", record.get("Y"));
         assertEquals("3", record.get("Z"));
-        Assert.assertEquals(3, record.size());
+        assertEquals(3, record.size());
     }
 
     @Test
@@ -1168,7 +1167,7 @@ public class CSVParserTest {
         assertEquals("1", record.get("X"));
         assertEquals("2", record.get("Y"));
         assertEquals("3", record.get("Z"));
-        Assert.assertEquals(3, record.size());
+        assertEquals(3, record.size());
     }
 
     @Test
@@ -1185,7 +1184,7 @@ public class CSVParserTest {
         final Iterator<CSVRecord> records = CSVFormat.RFC4180.parse(new StringReader(dqString)).iterator();
         final CSVRecord record = records.next();
         assertFalse(records.hasNext());
-        Assert.assertEquals(3, record.size());
+        assertEquals(3, record.size());
         assertEquals("aaa", record.get(0));
         assertEquals("b\"bb", record.get(1));
         assertEquals("ccc", record.get(2));

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -20,13 +20,14 @@ package org.apache.commons.csv;
 import static org.apache.commons.csv.Constants.CR;
 import static org.apache.commons.csv.Constants.CRLF;
 import static org.apache.commons.csv.Constants.LF;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,8 +51,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.io.input.BOMInputStream;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * CSVParserTest
@@ -155,7 +156,7 @@ public class CSVParserTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testBackslashEscapingOld() throws IOException {
         final String code = "one,two,three\n" + "on\\\"e,two\n" + "on\"e,two\n" + "one,\"tw\\\"o\"\n" +
                 "one,\"t\\,wo\"\n" + "one,two,\"th,ree\"\n" + "\"a\\\\\"\n" + "a\\,b\n" + "\"a\\\\,b\"";
@@ -176,7 +177,7 @@ public class CSVParserTest {
     }
 
     @Test
-    @Ignore("CSV-107")
+    @Disabled("CSV-107")
     public void testBOM() throws IOException {
         final URL url = ClassLoader.getSystemClassLoader().getResource("CSVFileParser/bom.csv");
         try (final CSVParser parser = CSVParser.parse(url, Charset.forName(UTF_8_NAME), CSVFormat.EXCEL.withHeader())) {
@@ -242,7 +243,7 @@ public class CSVParserTest {
         }
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testClose() throws Exception {
         final Reader in = new StringReader("# comment\na,b,c\n1,2,3\nx,y,z");
         final Iterator<CSVRecord> records;
@@ -251,7 +252,7 @@ public class CSVParserTest {
             assertTrue(records.hasNext());
         }
         assertFalse(records.hasNext());
-        records.next();
+        assertThrows(NoSuchElementException.class, records::next);
     }
 
     @Test
@@ -291,10 +292,12 @@ public class CSVParserTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDuplicateHeadersNotAllowed() throws Exception {
-        CSVParser.parse("a,b,a\n1,2,3\nx,y,z",
-                CSVFormat.DEFAULT.withHeader(new String[] {}).withAllowDuplicateHeaderNames(false));
+    @Test
+    public void testDuplicateHeadersNotAllowed() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVParser.parse("a,b,a\n1,2,3\nx,y,z",
+                        CSVFormat.DEFAULT.withHeader(new String[] {}).withAllowDuplicateHeaderNames(false)));
     }
 
     @Test
@@ -715,10 +718,10 @@ public class CSVParserTest {
         CSVFormat.DEFAULT.withHeader().withAllowMissingColumnNames().parse(in).iterator();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testHeadersMissingException() throws Exception {
+    @Test
+    public void testHeadersMissingException() {
         final Reader in = new StringReader("a,,c,,d\n1,2,3,4\nx,y,z,zz");
-        CSVFormat.DEFAULT.withHeader().parse(in).iterator();
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withHeader().parse(in).iterator());
     }
 
     @Test
@@ -743,12 +746,9 @@ public class CSVParserTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidFormat() throws Exception {
-        final CSVFormat invalidFormat = CSVFormat.DEFAULT.withDelimiter(CR);
-        try (final CSVParser parser = new CSVParser(null, invalidFormat)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testInvalidFormat() {
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter(CR));
     }
 
     @Test
@@ -884,7 +884,7 @@ public class CSVParserTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testMongoDbCsv() throws Exception {
         try (final CSVParser parser = CSVParser.parse("\"a a\",b,c" + LF + "d,e,f", CSVFormat.MONGODB_CSV)) {
             final Iterator<CSVRecord> itr1 = parser.iterator();
@@ -920,18 +920,14 @@ public class CSVParserTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNewCSVParserNullReaderFormat() throws Exception {
-        try (final CSVParser parser = new CSVParser(null, CSVFormat.DEFAULT)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testNewCSVParserNullReaderFormat() {
+        assertThrows(IllegalArgumentException.class, () -> new CSVParser(null, CSVFormat.DEFAULT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNewCSVParserReaderNullFormat() throws Exception {
-        try (final CSVParser parser = new CSVParser(new StringReader(""), null)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testNewCSVParserReaderNullFormat() {
+        assertThrows(IllegalArgumentException.class, () -> new CSVParser(new StringReader(""), null));
     }
 
     @Test
@@ -974,60 +970,56 @@ public class CSVParserTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseFileNullFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse(new File("CSVFileParser/test.csv"), Charset.defaultCharset(), null)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParseFileNullFormat() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVParser.parse(new File("CSVFileParser/test.csv"), Charset.defaultCharset(), null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseNullFileFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse((File) null, Charset.defaultCharset(), CSVFormat.DEFAULT)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParseNullFileFormat() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVParser.parse((File) null, Charset.defaultCharset(), CSVFormat.DEFAULT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseNullPathFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse((Path) null, Charset.defaultCharset(), CSVFormat.DEFAULT)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParseNullPathFormat() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVParser.parse((Path) null, Charset.defaultCharset(), CSVFormat.DEFAULT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseNullStringFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse((String) null, CSVFormat.DEFAULT)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParseNullStringFormat() {
+        assertThrows(IllegalArgumentException.class, () -> CSVParser.parse((String) null, CSVFormat.DEFAULT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseNullUrlCharsetFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse((URL) null, Charset.defaultCharset(), CSVFormat.DEFAULT)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParseNullUrlCharsetFormat() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVParser.parse((URL) null, Charset.defaultCharset(), CSVFormat.DEFAULT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParserUrlNullCharsetFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse(new URL("https://commons.apache.org"), null, CSVFormat.DEFAULT)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParserUrlNullCharsetFormat() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVParser.parse(new URL("https://commons.apache.org"), null, CSVFormat.DEFAULT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseStringNullFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse("csv data", (CSVFormat) null)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParseStringNullFormat() {
+        assertThrows(IllegalArgumentException.class, () -> CSVParser.parse("csv data", (CSVFormat) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseUrlCharsetNullFormat() throws Exception {
-        try (final CSVParser parser = CSVParser.parse(new URL("https://commons.apache.org"), Charset.defaultCharset(), null)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testParseUrlCharsetNullFormat() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CSVParser.parse(new URL("https://commons.apache.org"), Charset.defaultCharset(), null));
     }
 
     @Test
@@ -1128,7 +1120,7 @@ public class CSVParserTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testStartWithEmptyLinesThenHeaders() throws Exception {
         final String[] codes = { "\r\n\r\n\r\nhello,\r\n\r\n\r\n", "hello,\n\n\n", "hello,\"\"\r\n\r\n\r\n",
                 "hello,\"\"\n\n\n" };

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -21,6 +21,7 @@ import static org.apache.commons.csv.Constants.CR;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -55,7 +56,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.SimpleResultSet;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -582,7 +582,7 @@ public class CSVPrinterTest {
     public void testInvalidFormat() throws Exception {
         final CSVFormat invalidFormat = CSVFormat.DEFAULT.withDelimiter(CR);
         try (final CSVPrinter printer = new CSVPrinter(new StringWriter(), invalidFormat)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
@@ -882,14 +882,14 @@ public class CSVPrinterTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNewCsvPrinterAppendableNullFormat() throws Exception {
         try (final CSVPrinter printer = new CSVPrinter(new StringWriter(), null)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNewCsvPrinterNullAppendableFormat() throws Exception {
         try (final CSVPrinter printer = new CSVPrinter(null, CSVFormat.DEFAULT)) {
-            Assert.fail("This test should have thrown an exception.");
+            fail("This test should have thrown an exception.");
         }
     }
 

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -18,10 +18,10 @@
 package org.apache.commons.csv;
 
 import static org.apache.commons.csv.Constants.CR;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -56,8 +56,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.SimpleResultSet;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -578,12 +578,9 @@ public class CSVPrinterTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidFormat() throws Exception {
-        final CSVFormat invalidFormat = CSVFormat.DEFAULT.withDelimiter(CR);
-        try (final CSVPrinter printer = new CSVPrinter(new StringWriter(), invalidFormat)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testInvalidFormat() {
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter(CR));
     }
 
     @Test
@@ -633,7 +630,7 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testJira135_part1() throws IOException {
         final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH_CH);
         final StringWriter sw = new StringWriter();
@@ -649,7 +646,7 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testJira135_part2() throws IOException {
         final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH_CH);
         final StringWriter sw = new StringWriter();
@@ -665,7 +662,7 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testJira135_part3() throws IOException {
         final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH_CH);
         final StringWriter sw = new StringWriter();
@@ -681,7 +678,7 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testJira135All() throws IOException {
         final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH_CH);
         final StringWriter sw = new StringWriter();
@@ -879,18 +876,14 @@ public class CSVPrinterTest {
         assertEquals("\\N", CSVFormat.MYSQL.getNullString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNewCsvPrinterAppendableNullFormat() throws Exception {
-        try (final CSVPrinter printer = new CSVPrinter(new StringWriter(), null)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testNewCsvPrinterAppendableNullFormat() {
+        assertThrows(IllegalArgumentException.class, () -> new CSVPrinter(new StringWriter(), null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNewCsvPrinterNullAppendableFormat() throws Exception {
-        try (final CSVPrinter printer = new CSVPrinter(null, CSVFormat.DEFAULT)) {
-            fail("This test should have thrown an exception.");
-        }
+    @Test
+    public void testNewCsvPrinterNullAppendableFormat() {
+        assertThrows(IllegalArgumentException.class, () -> new CSVPrinter(null, CSVFormat.DEFAULT));
     }
 
     @Test
@@ -942,7 +935,7 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPostgreSqlCsvNullOutput() throws IOException {
         Object[] s = new String[] { "NULL", null };
         CSVFormat format = CSVFormat.POSTGRESQL_CSV.withQuote(DQUOTE_CHAR).withNullString("NULL").withQuoteMode(QuoteMode.ALL_NON_NULL);
@@ -1045,7 +1038,7 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testPostgreSqlCsvTextOutput() throws IOException {
         Object[] s = new String[] { "NULL", null };
         CSVFormat format = CSVFormat.POSTGRESQL_TEXT.withQuote(DQUOTE_CHAR).withNullString("NULL").withQuoteMode(QuoteMode.ALL_NON_NULL);
@@ -1403,7 +1396,7 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testRandomMongoDbCsv() throws Exception {
         doRandom(CSVFormat.MONGODB_CSV, ITERATIONS_FOR_RANDOM_TEST);
     }
@@ -1414,19 +1407,19 @@ public class CSVPrinterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testRandomOracle() throws Exception {
         doRandom(CSVFormat.ORACLE, ITERATIONS_FOR_RANDOM_TEST);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testRandomPostgreSqlCsv() throws Exception {
         doRandom(CSVFormat.POSTGRESQL_CSV, ITERATIONS_FOR_RANDOM_TEST);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testRandomPostgreSqlText() throws Exception {
         doRandom(CSVFormat.POSTGRESQL_TEXT, ITERATIONS_FOR_RANDOM_TEST);
     }

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -31,8 +32,8 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CSVRecordTest {
 
@@ -44,7 +45,7 @@ public class CSVRecordTest {
     private CSVRecord record, recordWithHeader;
     private Map<String, Integer> headerMap;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         values = new String[] { "A", "B", "C" };
         final String rowData = StringUtils.join(values, ',');
@@ -72,35 +73,35 @@ public class CSVRecordTest {
         assertEquals(values[2], recordWithHeader.get("third"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetStringInconsistentRecord() {
         headerMap.put("fourth", Integer.valueOf(4));
-        recordWithHeader.get("fourth");
+        assertThrows(IllegalArgumentException.class, () -> recordWithHeader.get("fourth"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testGetStringNoHeader() {
-        record.get("first");
+        assertThrows(IllegalStateException.class, () -> record.get("first"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetUnmappedEnum() {
-        assertNull(recordWithHeader.get(EnumFixture.UNKNOWN_COLUMN));
+        assertThrows(IllegalArgumentException.class, () -> recordWithHeader.get(EnumFixture.UNKNOWN_COLUMN));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetUnmappedName() {
-        assertNull(recordWithHeader.get("fourth"));
+        assertThrows(IllegalArgumentException.class, () -> assertNull(recordWithHeader.get("fourth")));
     }
 
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
+    @Test
     public void testGetUnmappedNegativeInt() {
-        assertNull(recordWithHeader.get(Integer.MIN_VALUE));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> recordWithHeader.get(Integer.MIN_VALUE));
     }
 
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
+    @Test
     public void testGetUnmappedPositiveInt() {
-        assertNull(recordWithHeader.get(Integer.MAX_VALUE));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> recordWithHeader.get(Integer.MAX_VALUE));
     }
 
     @Test
@@ -192,8 +193,8 @@ public class CSVRecordTest {
         try (final CSVParser parser = CSVParser.parse("a,b", CSVFormat.newFormat(','))) {
             final CSVRecord shortRec = parser.iterator().next();
             final Map<String, String> map = shortRec.toMap();
-            assertNotNull("Map is not null.", map);
-            assertTrue("Map is empty.", map.isEmpty());
+            assertNotNull(map, "Map is not null.");
+            assertTrue(map.isEmpty(), "Map is empty.");
         }
     }
 

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -31,7 +31,6 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -170,7 +169,7 @@ public class CSVRecordTest {
             final ArrayList<String> list = new ArrayList<>(map.values());
             Collections.sort(list);
             printer.printRecord(list);
-            Assert.assertEquals("A,B,C,NewValue" + CSVFormat.DEFAULT.getRecordSeparator(), printer.getOut().toString());
+            assertEquals("A,B,C,NewValue" + CSVFormat.DEFAULT.getRecordSeparator(), printer.getOut().toString());
         }
     }
 

--- a/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
+++ b/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
@@ -19,13 +19,13 @@ package org.apache.commons.csv;
 
 import static org.apache.commons.csv.Constants.END_OF_STREAM;
 import static org.apache.commons.csv.Constants.UNDEFINED;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -28,15 +28,16 @@ import static org.apache.commons.csv.Token.Type.EORECORD;
 import static org.apache.commons.csv.Token.Type.TOKEN;
 import static org.apache.commons.csv.TokenMatchers.hasContent;
 import static org.apache.commons.csv.TokenMatchers.matches;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -45,7 +46,7 @@ public class LexerTest {
 
     private CSVFormat formatWithEscaping;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         formatWithEscaping = CSVFormat.DEFAULT.withEscape('\\');
     }
@@ -142,7 +143,7 @@ public class LexerTest {
                 "\n" + // 6c
                 "# Final comment\n"; // 7
         final CSVFormat format = CSVFormat.DEFAULT.withCommentMarker('#').withIgnoreEmptyLines(false);
-        assertFalse("Should not ignore empty lines", format.getIgnoreEmptyLines());
+        assertFalse(format.getIgnoreEmptyLines(), "Should not ignore empty lines");
 
         try (final Lexer parser = createLexer(code, format)) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "1"));
@@ -381,11 +382,11 @@ public class LexerTest {
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testEscapingAtEOF() throws Exception {
         final String code = "escaping at EOF is evil\\";
         try (final Lexer lexer = createLexer(code, formatWithEscaping)) {
-            lexer.nextToken(new Token());
+            assertThrows(IOException.class, () -> lexer.nextToken(new Token()));
         }
     }
 }

--- a/src/test/java/org/apache/commons/csv/TokenMatchersTest.java
+++ b/src/test/java/org/apache/commons/csv/TokenMatchersTest.java
@@ -20,17 +20,17 @@ import static org.apache.commons.csv.TokenMatchers.hasContent;
 import static org.apache.commons.csv.TokenMatchers.hasType;
 import static org.apache.commons.csv.TokenMatchers.isReady;
 import static org.apache.commons.csv.TokenMatchers.matches;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TokenMatchersTest {
 
     private Token token;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         token = new Token();
         token.type = Token.Type.TOKEN;

--- a/src/test/java/org/apache/commons/csv/Utils.java
+++ b/src/test/java/org/apache/commons/csv/Utils.java
@@ -18,9 +18,10 @@
 
 package org.apache.commons.csv;
 
-import java.util.List;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.Assert;
+import java.util.List;
 
 /**
  * Utility methods for test cases
@@ -38,9 +39,9 @@ final class Utils {
      * @param actual the List of {@link CSVRecord} entries, each containing an array of values
      */
     public static void compare(final String message, final String[][] expected, final List<CSVRecord> actual) {
-        Assert.assertEquals(message+"  - outer array size", expected.length, actual.size());
+        assertEquals(message+"  - outer array size", expected.length, actual.size());
         for (int i = 0; i < expected.length; i++) {
-            Assert.assertArrayEquals(message + " (entry " + i + ")", expected[i], actual.get(i).values());
+            assertArrayEquals(message + " (entry " + i + ")", expected[i], actual.get(i).values());
         }
     }
 }

--- a/src/test/java/org/apache/commons/csv/Utils.java
+++ b/src/test/java/org/apache/commons/csv/Utils.java
@@ -18,8 +18,8 @@
 
 package org.apache.commons.csv;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -39,9 +39,9 @@ final class Utils {
      * @param actual the List of {@link CSVRecord} entries, each containing an array of values
      */
     public static void compare(final String message, final String[][] expected, final List<CSVRecord> actual) {
-        assertEquals(message+"  - outer array size", expected.length, actual.size());
+        assertEquals(expected.length, actual.size(), message + "  - outer array size");
         for (int i = 0; i < expected.length; i++) {
-            assertArrayEquals(message + " (entry " + i + ")", expected[i], actual.get(i).values());
+            assertArrayEquals(expected[i], actual.get(i).values(), message + " (entry " + i + ")");
         }
     }
 }

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv164Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv164Test.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.csv.issues;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JiraCsv164Test {
 
@@ -37,7 +37,7 @@ public class JiraCsv164Test {
             printer.print("B");
         }
         final String s = out.toString();
-        assertTrue(s, s.contains(comment));
+        assertTrue(s.contains(comment), s);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class JiraCsv164Test {
             printer.print("B");
         }
         final String s = out.toString();
-        assertTrue(s, s.contains(comment));
+        assertTrue(s.contains(comment), s);
     }
 
 }

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv167Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv167Test.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.csv.issues;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,7 +28,6 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.csv.QuoteMode;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class JiraCsv167Test {
@@ -77,8 +78,8 @@ public class JiraCsv167Test {
             }
         }
         // Comment lines are concatenated, in this example 4 lines become 2 comments.
-        Assert.assertEquals(totcomment, comments);
-        Assert.assertEquals(totrecs, records); // records includes the header
+        assertEquals(totcomment, comments);
+        assertEquals(totrecs, records); // records includes the header
     }
 
     private Reader getTestInput() {

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv167Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv167Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.csv.issues;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.csv.QuoteMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JiraCsv167Test {
 

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv198Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv198Test.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.csv.issues;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -24,7 +26,6 @@ import java.io.UnsupportedEncodingException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class JiraCsv198Test {
@@ -34,12 +35,12 @@ public class JiraCsv198Test {
     @Test
     public void test() throws UnsupportedEncodingException, IOException {
         final InputStream pointsOfReference = getClass().getResourceAsStream("/CSV-198/optd_por_public.csv");
-        Assert.assertNotNull(pointsOfReference);
+        assertNotNull(pointsOfReference);
         try (@SuppressWarnings("resource")
         CSVParser parser = CSV_FORMAT.parse(new InputStreamReader(pointsOfReference, "UTF-8"))) {
             for (final CSVRecord record : parser) {
                 final String locationType = record.get("location_type");
-                Assert.assertNotNull(locationType);
+                assertNotNull(locationType);
             }
         }
     }

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv198Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv198Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.csv.issues;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,7 +26,7 @@ import java.io.UnsupportedEncodingException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JiraCsv198Test {
 

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv203Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv203Test.java
@@ -16,10 +16,11 @@
  */
 package org.apache.commons.csv.issues;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -38,7 +39,7 @@ public class JiraCsv203Test {
         try (final CSVPrinter printer = new CSVPrinter(buffer, format)) {
             printer.printRecord(new Object[] { null, "Hello", null, "World" });
         }
-        Assert.assertEquals("\"N/A\",\"Hello\",\"N/A\",\"World\"\r\n", buffer.toString());
+        assertEquals("\"N/A\",\"Hello\",\"N/A\",\"World\"\r\n", buffer.toString());
     }
 
     @Test
@@ -52,7 +53,7 @@ public class JiraCsv203Test {
         try (final CSVPrinter printer = new CSVPrinter(buffer, format)) {
             printer.printRecord(new Object[] { null, "Hello", null, "World" });
         }
-        Assert.assertEquals("N/A,\"Hello\",N/A,\"World\"\r\n", buffer.toString());
+        assertEquals("N/A,\"Hello\",N/A,\"World\"\r\n", buffer.toString());
     }
 
     @Test
@@ -65,7 +66,7 @@ public class JiraCsv203Test {
         try (final CSVPrinter printer = new CSVPrinter(buffer, format)) {
             printer.printRecord(new Object[] { null, "Hello", null, "World" });
         }
-        Assert.assertEquals("N/A,Hello,N/A,World\r\n", buffer.toString());
+        assertEquals("N/A,Hello,N/A,World\r\n", buffer.toString());
     }
 
     @Test
@@ -79,7 +80,7 @@ public class JiraCsv203Test {
         try (final CSVPrinter printer = new CSVPrinter(buffer, format)) {
             printer.printRecord(new Object[] { null, "Hello", null, "World" });
         }
-        Assert.assertEquals("N/A,Hello,N/A,World\r\n", buffer.toString());
+        assertEquals("N/A,Hello,N/A,World\r\n", buffer.toString());
     }
 
     @Test
@@ -93,7 +94,7 @@ public class JiraCsv203Test {
         try (final CSVPrinter printer = new CSVPrinter(buffer, format)) {
             printer.printRecord(new Object[] { null, "Hello", null, "World" });
         }
-        Assert.assertEquals("N/A,\"Hello\",N/A,\"World\"\r\n", buffer.toString());
+        assertEquals("N/A,\"Hello\",N/A,\"World\"\r\n", buffer.toString());
     }
 
     @Test
@@ -107,7 +108,7 @@ public class JiraCsv203Test {
         try (final CSVPrinter printer = new CSVPrinter(buffer, format)) {
             printer.printRecord(new Object[] { null, "Hello", null, "World" });
         }
-        Assert.assertEquals(",\"Hello\",,\"World\"\r\n", buffer.toString());
+        assertEquals(",\"Hello\",,\"World\"\r\n", buffer.toString());
     }
 
     @Test
@@ -122,6 +123,6 @@ public class JiraCsv203Test {
             printer.printRecord(new Object[] { "", "Hello", "", "World" });
             //printer.printRecord(new Object[] { null, "Hello", null, "World" });
         }
-        Assert.assertEquals("\"\",\"Hello\",\"\",\"World\"\r\n", buffer.toString());
+        assertEquals("\"\",\"Hello\",\"\",\"World\"\r\n", buffer.toString());
     }
 }

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv203Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv203Test.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.csv.issues;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JIRA: <a href="https://issues.apache.org/jira/browse/CSV-203">withNullString value is printed without quotes when QuoteMode.ALL is specified</a>

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv213Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv213Test.java
@@ -26,8 +26,8 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.csv.QuoteMode;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests https://issues.apache.org/jira/browse/CSV-213
@@ -37,7 +37,7 @@ import org.junit.Test;
  * create a new Iterator you are only created a new view on the same position in the parser's stream. For the behavior
  * you want, you need to open a new CSVParser.
  */
-@Ignore
+@Disabled
 public class JiraCsv213Test {
 
     private void createEndChannel(final File csvFile) {

--- a/src/test/java/org/apache/commons/csv/issues/JiraCvs249Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCvs249Test.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.csv.issues;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -28,7 +28,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JiraCvs249Test {
 

--- a/src/test/java/org/apache/commons/csv/issues/JiraCvs249Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCvs249Test.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.csv.issues;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -26,7 +28,6 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class JiraCvs249Test {
@@ -48,8 +49,8 @@ public class JiraCvs249Test {
         }
 
         records.forEach(record -> {
-            Assert.assertEquals("foo \\", record.get(0));
-            Assert.assertEquals("bar", record.get(1));
+            assertEquals("foo \\", record.get(0));
+            assertEquals("bar", record.get(1));
         });
 
     }

--- a/src/test/java/org/apache/commons/csv/perf/PerformanceTest.java
+++ b/src/test/java/org/apache/commons/csv/perf/PerformanceTest.java
@@ -32,8 +32,8 @@ import java.util.zip.GZIPInputStream;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.IOUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests performance.
@@ -47,7 +47,7 @@ public class PerformanceTest {
 
     private static final File BIG_FILE = new File(System.getProperty("java.io.tmpdir"), "worldcitiespop.txt");
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws FileNotFoundException, IOException {
         if (BIG_FILE.exists()) {
             System.out.println(String.format("Found test fixture %s: %,d bytes.", BIG_FILE, BIG_FILE.length()));


### PR DESCRIPTION
This PR upgrades the project's testing framework from JUnit 4.12 to the modern JUnit Jupiter 5.5.4.

Since JUnit 5 Jupiter is not backwards compatible to JUnit 4.x (or even JUnit Vintage), this patch is a bit large, even though a lot of the changes are merely cosmetic (such as changing the argument order, see details below). In order to make the reviewer's task as easy as possible, this PR does not presume to use JUnit Jupiter's best practices and all its new functionality, but only to migrate the existing tests with as little change as possible. Following PRs may want to improve the tests by using some of JUnit Jupiter's new features.

This PR includes the following changes:

1. Maven dependency changes:
     1. `junit:junit` was replaced with `org.junit.jupiter:junit-jupiter`.
     1. `org.hamcrest:hamcrest` was introduced as an explicit dependency, since the project uses Hamcrest, and JUnit Jupiter does not bundle Hamcrest, unlike JUnit 4.x.
     1. The Mockito dependency was upgraded from `org.mockito.mockito-all:1.10.19` to `org.mockito:mockito-core:3.1.0`, which supports JUnit Jupiter.

 1. Annotations:
      1. `org.junit.jupiter.api.Test` was used as a drop in replacement for `org.juit.Test` without arguments. See 3.ii. for handling of `@Test` annotations with an `expected` argument.
     1. `org.junit.jupiter.api.BeforeEach` was used as a drop in replacement for `org.junit.Before`.
     1. `org.junit.jupiter.api.BeforeAll` was used as a drop in replacement for `org.junit.BeforeClass`.
     1. `org.junit.jupiter.api.Disabled` was used as a drop in replacement for `org.junit.Ignore`.

1. Assertions:
     1. `org.junit.jupiter.api.Assertions`' methods were used as drop in replacements for `org.junit.Assert`'s methods with the same name in the simple case of an assertion without a message. In the case of an assertion with a message, `org.junit.jupiter.api.Assertions`' methods were used, but the argument order was changed - `Assert`'s methods take the message as the first argument, while `Assertions`' methods take the message as the last argument.
     1. `org.junit.jupiter.api.Assertions#assertThrows` was used to assert that a specific exception was thrown instead of an `org.junit.Test` annotation with an `expected` argument. This technique has a couple of side bonuses. First, it makes the tests slightly stricter, as now they can assert the exception was thrown from a specific line and prevent false positives where the test's "set-up" code accidentally threw that exception. Second, it clarifies that some of the test code is unreachable (as a previous line already throws an exception), and can safely be removed in order to clean up the test. The throws clauses of these methods were cleaned up from exceptions that can no longer be thrown in order to avoid compilation warnings.
     1. `org.hamcrest.MatcherAssert#assertThat` was used as a drop in replacement for `org.junit.Assert#assertThat`.
     1. `org.junit.jupiter.api.Assertions#assertNull` was used as a drop in replacement for `junit.framework.TestCase#assertNull`.

1. Specific Changes:
     1. `CSVFileParserTest` was rewritten with JUnit Jupiter's `org.junit.jupiter.api.ParameterizedTest`.  Unlike JUnit 4's `org.junit.runners.Parameterized`, it cannot be used to inject arguments to a test's construct, and so the test can't be stateful. Instead, it was rewritten so every test receives the file as a parameter, and opens a reader on it itself. As a side bonus, this design makes it easier to close the reader and avoid leaving open file descriptors like the original test did.


Closes CSV-252