### PR TITLE
[CSV-253] Handle absent values in input

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -266,7 +266,7 @@ public final class CSVFormat implements Serializable {
      * @see Predefined#Default
      */
     public static final CSVFormat DEFAULT = new CSVFormat(COMMA, DOUBLE_QUOTE_CHAR, null, null, null, false, true, CRLF,
-            null, null, null, false, false, false, false, false, false, true);
+            null, false, null, null, false, false, false, false, false, false, true);
 
     /**
      * Excel file format (using a comma as the value delimiter). Note that the actual value delimiter used by Excel is
@@ -672,7 +672,7 @@ public final class CSVFormat implements Serializable {
      * @see #TDF
      */
     public static CSVFormat newFormat(final char delimiter) {
-        return new CSVFormat(delimiter, null, null, null, null, false, false, null, null, null, null, false, false,
+        return new CSVFormat(delimiter, null, null, null, null, false, false, null, null, false, null, null, false, false,
                 false, false, false, false, true);
     }
 
@@ -711,6 +711,8 @@ public final class CSVFormat implements Serializable {
     private final boolean ignoreSurroundingSpaces; // Should leading/trailing spaces be ignored around values?
 
     private final String nullString; // the string to be used for null values
+
+    private final boolean absentMeansNull;   // if absent values in input should be treated as null
 
     private final Character quoteCharacter; // null if quoting is disabled
 
@@ -767,7 +769,7 @@ public final class CSVFormat implements Serializable {
      */
     private CSVFormat(final char delimiter, final Character quoteChar, final QuoteMode quoteMode,
             final Character commentStart, final Character escape, final boolean ignoreSurroundingSpaces,
-            final boolean ignoreEmptyLines, final String recordSeparator, final String nullString,
+            final boolean ignoreEmptyLines, final String recordSeparator, final String nullString, final boolean absentMeansNull,
             final Object[] headerComments, final String[] header, final boolean skipHeaderRecord,
             final boolean allowMissingColumnNames, final boolean ignoreHeaderCase, final boolean trim,
             final boolean trailingDelimiter, final boolean autoFlush, final boolean allowDuplicateHeaderNames) {
@@ -781,6 +783,7 @@ public final class CSVFormat implements Serializable {
         this.ignoreEmptyLines = ignoreEmptyLines;
         this.recordSeparator = recordSeparator;
         this.nullString = nullString;
+        this.absentMeansNull = absentMeansNull;
         this.headerComments = toStringArray(headerComments);
         this.header = header == null ? null : header.clone();
         this.skipHeaderRecord = skipHeaderRecord;
@@ -856,6 +859,9 @@ public final class CSVFormat implements Serializable {
                 return false;
             }
         } else if (!nullString.equals(other.nullString)) {
+            return false;
+        }
+        if (absentMeansNull != other.absentMeansNull) {
             return false;
         }
         if (!Arrays.equals(header, other.header)) {
@@ -1018,6 +1024,16 @@ public final class CSVFormat implements Serializable {
     public String getNullString() {
         return nullString;
     }
+    
+    /**
+     * Specifies how absent values in input are treated.
+     * 
+     * @see #withAbsentMeansNull(boolean) 
+     * @return if absent values in input should be translated to {@code null}
+     */
+    public boolean getAbsentMeansNull() {
+        return absentMeansNull;
+    }
 
     /**
      * Returns the character used to encapsulate values containing special characters.
@@ -1087,6 +1103,7 @@ public final class CSVFormat implements Serializable {
         result = prime * result + ((commentMarker == null) ? 0 : commentMarker.hashCode());
         result = prime * result + ((escapeCharacter == null) ? 0 : escapeCharacter.hashCode());
         result = prime * result + ((nullString == null) ? 0 : nullString.hashCode());
+        result = prime * result + (absentMeansNull ? 1231 : 1237);
         result = prime * result + (ignoreSurroundingSpaces ? 1231 : 1237);
         result = prime * result + (ignoreHeaderCase ? 1231 : 1237);
         result = prime * result + (ignoreEmptyLines ? 1231 : 1237);
@@ -1732,7 +1749,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withAllowDuplicateHeaderNames(final boolean allowDuplicateHeaderNames) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -1758,7 +1775,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withAllowMissingColumnNames(final boolean allowMissingColumnNames) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -1774,7 +1791,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withAutoFlush(final boolean autoFlush) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -1810,7 +1827,7 @@ public final class CSVFormat implements Serializable {
             throw new IllegalArgumentException("The comment start marker character cannot be a line break");
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -1829,7 +1846,7 @@ public final class CSVFormat implements Serializable {
             throw new IllegalArgumentException("The delimiter cannot be a line break");
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -1861,7 +1878,7 @@ public final class CSVFormat implements Serializable {
             throw new IllegalArgumentException("The escape character cannot be a line break");
         }
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escape, ignoreSurroundingSpaces,
-                ignoreEmptyLines, recordSeparator, nullString, headerComments, header, skipHeaderRecord,
+                ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header, skipHeaderRecord,
                 allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2018,7 +2035,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withHeader(final String... header) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2040,7 +2057,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withHeaderComments(final Object... headerComments) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2066,7 +2083,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withIgnoreEmptyLines(final boolean ignoreEmptyLines) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2093,7 +2110,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withIgnoreHeaderCase(final boolean ignoreHeaderCase) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2119,7 +2136,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withIgnoreSurroundingSpaces(final boolean ignoreSurroundingSpaces) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2139,11 +2156,57 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withNullString(final String nullString) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
 
+    
+    /**
+     * Returns a new {@code CSVFormat} with the absent-value-is-null behavior of the format set to {@code true}.
+     *
+     * @return A new CSVFormat that is equal to this but with the specified absent value behavior.
+     * @see #withAbsentMeansNull(boolean)
+     * @since 1.8
+     */
+    public CSVFormat withAbsentMeansNull() {
+        return this.withAbsentMeansNull(true);
+    }
+
+    /**
+     * Returns a new {@code CSVFormat} with the absent-value-means-null behavior 
+     * of the format set to specified value.
+     * 
+     * <p>An absent value is when there are zero characters between field 
+     * delimiters. For example:
+     * 
+     * <pre>
+     *    "John",,"Doe"    // 2nd element is absent
+     *    ,"AA",123        // 1st element is absent
+     *    "John",90,       // 3rd element is absent
+     *    "",,90           // 2nd element is absent (1st element isn't)
+     * </pre>
+     * Note: A quoted value is never "absent".
+     * 
+     * <p>This setting only affects parsing, not writing.  To print {@code null} 
+     * values as absent values you must set {@code nullString} to {@code null}.
+     * 
+     * @param absentMeansNull the behavior for absent values when parsing, 
+     *     {@code true} to parse absent values to {@code null},
+     *     {@code false} to parse to zero-length string (which in turn may be
+     *         translated to {@code null} if {@code nullString} is "").
+     * @return A new CSVFormat that is equal to this but with the specified absent value behavior.
+     * @see #withNullString(java.lang.String) 
+     * @since 1.8
+     */
+    public CSVFormat withAbsentMeansNull(boolean absentMeansNull) {
+        return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
+                skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
+                allowDuplicateHeaderNames);
+    }
+    
+    
     /**
      * Returns a new {@code CSVFormat} with the quoteChar of the format set to the specified character.
      *
@@ -2171,7 +2234,7 @@ public final class CSVFormat implements Serializable {
             throw new IllegalArgumentException("The quoteChar cannot be a line break");
         }
         return new CSVFormat(delimiter, quoteChar, quoteMode, commentMarker, escapeCharacter, ignoreSurroundingSpaces,
-                ignoreEmptyLines, recordSeparator, nullString, headerComments, header, skipHeaderRecord,
+                ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header, skipHeaderRecord,
                 allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2186,7 +2249,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withQuoteMode(final QuoteMode quoteModePolicy) {
         return new CSVFormat(delimiter, quoteCharacter, quoteModePolicy, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2225,7 +2288,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withRecordSeparator(final String recordSeparator) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2253,7 +2316,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withSkipHeaderRecord(final boolean skipHeaderRecord) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2295,7 +2358,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withTrailingDelimiter(final boolean trailingDelimiter) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }
@@ -2323,7 +2386,7 @@ public final class CSVFormat implements Serializable {
      */
     public CSVFormat withTrim(final boolean trim) {
         return new CSVFormat(delimiter, quoteCharacter, quoteMode, commentMarker, escapeCharacter,
-                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, headerComments, header,
+                ignoreSurroundingSpaces, ignoreEmptyLines, recordSeparator, nullString, absentMeansNull, headerComments, header,
                 skipHeaderRecord, allowMissingColumnNames, ignoreHeaderCase, trim, trailingDelimiter, autoFlush,
                 allowDuplicateHeaderNames);
     }

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -422,8 +422,16 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         if (lastRecord && inputClean.isEmpty() && this.format.getTrailingDelimiter()) {
             return;
         }
+        boolean isAbsent = (this.reusableToken.isAbsentValue);
         final String nullString = this.format.getNullString();
-        this.recordList.add(inputClean.equals(nullString) ? null : inputClean);
+        this.recordList.add(setNullValue(inputClean, nullString, this.format.getAbsentMeansNull(), isAbsent));
+    }
+    
+    private String setNullValue(String value, String nullString, boolean absentIsNull, boolean isAbsent) {
+        if (absentIsNull && isAbsent) {
+            return null;
+        }
+        return (value.equals(nullString)) ? null : value;
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -88,6 +88,8 @@ final class Lexer implements Closeable {
      */
     Token nextToken(final Token token) throws IOException {
 
+        token.isAbsentValue = false;  // reset flag
+        
         // get the last read char (required for empty line detection)
         int lastChar = reader.getLastChar();
 
@@ -148,10 +150,12 @@ final class Lexer implements Closeable {
             // ok, start of token reached: encapsulated, or token
             if (isDelimiter(c)) {
                 // empty token return TOKEN("")
+                token.isAbsentValue = true;
                 token.type = TOKEN;
             } else if (eol) {
                 // empty token return EORECORD("")
                 // noop: token.content.append("");
+                token.isAbsentValue = true;
                 token.type = EORECORD;
             } else if (isQuoteChar(c)) {
                 // consume encapsulated token
@@ -159,6 +163,7 @@ final class Lexer implements Closeable {
             } else if (isEndOfFile(c)) {
                 // end of file return EOF()
                 // noop: token.content.append("");
+                token.isAbsentValue = true;
                 token.type = EOF;
                 token.isReady = true; // there is data at EOF
             } else {

--- a/src/main/java/org/apache/commons/csv/Token.java
+++ b/src/main/java/org/apache/commons/csv/Token.java
@@ -55,6 +55,13 @@ final class Token {
     /** Token ready flag: indicates a valid token with content (ready for the parser). */
     boolean isReady;
 
+    /**
+     * If the token was surrounded by delimeters on both sides with zero chars
+     * in between. This is known as an "absent" value. Note that an encapsulated
+     * value by definition is never an absent value.
+     */
+    boolean isAbsentValue = false;
+    
     void reset() {
         content.setLength(0);
         type = INVALID;

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -176,6 +176,52 @@ public class CSVParserTest {
     }
 
     @Test
+    public void testAbsentValue() throws IOException {
+        // Test the absentMeansNull feature
+
+        final String code = 
+                "John,,Doe\n"  // 1)
+                + ",John,Doe\n" // 2)
+                + "John,\"\",Doe\n" // 3)
+                + "John,Doe,\n" // 4)
+                ;
+        final String[][] res1 = {     // the result to match if absentIsNull is true
+            { "John", null, "Doe"},   // 1)
+            { null, "John", "Doe"},   // 2)
+            { "John", "", "Doe"},     // 3)
+            { "John", "Doe", null}    // 4)
+        };
+        final String[][] res2 = {     // the result to match if absentIsNull is false
+            { "John", "", "Doe"},     // 1)
+            { "", "John", "Doe"},     // 2)
+            { "John", "", "Doe"},     // 3)
+            { "John", "Doe", ""}      // 4)
+        };
+
+        final CSVFormat format1 = CSVFormat.DEFAULT
+                .withAbsentMeansNull()
+                .withRecordSeparator('\n');
+
+        try (final CSVParser parser = CSVParser.parse(code, format1)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertTrue(records.size() > 0);
+
+            Utils.compare("", res1, records);
+        }
+
+
+        final CSVFormat format2 = CSVFormat.DEFAULT
+                .withRecordSeparator('\n');
+
+        try (final CSVParser parser = CSVParser.parse(code, format2)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertTrue(records.size() > 0);
+
+            Utils.compare("", res2, records);
+        }
+    }
+    
+    @Test
     @Disabled("CSV-107")
     public void testBOM() throws IOException {
         final URL url = ClassLoader.getSystemClassLoader().getResource("CSVFileParser/bom.csv");


### PR DESCRIPTION
Being able to appropriately translate an absent value in CSV input with a Java `null` value. Previously, there was no way to do this, such a value would at best become a zero-length string when parsing. This made it impossible to correctly parse CSV output from say databases.

This PR is in reference to [CSV-253](https://issues.apache.org/jira/browse/CSV-253).

The PR addresses the issue by adding a flag on `Token` so that it becomes possible to distinguish between a token which is the result of an absent value in input or an actual zero-length string. A new modifier, `absentIsNull` is introduced on `CSVFormat`.   All existing formats and functionality are kept as-is, meaning the new feature is fully based on opt-in.

As a possible next step the pre-defined CSV formats for databases (i.e. `INFORMIX_UNLOAD_CSV`, `MYSQL`, `ORACLE` and `POSTGRESQL_CSV`) should be reviewed. I suspect that at least `POSTGRESQL_CSV` has always been incorrect in this matter. With this PR it can be corrected (if need be).

I've taken the liberty of adding "since 1.8" in the Javadocs since I see some commits for preparing such a release. Thus, hoping to include this.

