### PR TITLE
Add CSVRecord.isSet(int) method

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -215,6 +215,17 @@ public final class CSVRecord implements Serializable, Iterable<String> {
     }
 
     /**
+     * Checks whether a column with given index has a value.
+     *
+     * @param i
+     *         a column index (0-based)
+     * @return whether a column with given index has a value
+     */
+    public boolean isSet(final int i) {
+        return 0 <= i && i < values.length;
+    }
+
+    /**
      * Returns an iterator over the values of this record.
      *
      * @return an iterator over the values of this record.

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -211,7 +211,7 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      * @return whether a given columns is mapped and has a value
      */
     public boolean isSet(final String name) {
-        return isMapped(name) && getHeaderMapRaw().get(name).intValue() < values.length;
+        return isMapped(name) && getHeaderMapRaw().get(name) < values.length;
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -211,7 +211,7 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      * @return whether a given columns is mapped and has a value
      */
     public boolean isSet(final String name) {
-        return isMapped(name) && getHeaderMapRaw().get(name) < values.length;
+        return isMapped(name) && getHeaderMapRaw().get(name).intValue() < values.length;
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -134,10 +134,20 @@ public class CSVRecordTest {
     }
 
     @Test
-    public void testIsSet() {
+    public void testIsSetString() {
         assertFalse(record.isSet("first"));
         assertTrue(recordWithHeader.isSet("first"));
         assertFalse(recordWithHeader.isSet("fourth"));
+    }
+
+    @Test
+    public void testIsSetInt() {
+        assertFalse(record.isSet(-1));
+        assertTrue(record.isSet(0));
+        assertTrue(record.isSet(2));
+        assertFalse(record.isSet(3));
+        assertTrue(recordWithHeader.isSet(1));
+        assertFalse(recordWithHeader.isSet(1000));
     }
 
     @Test


### PR DESCRIPTION
Added the isSet(int) method to CSVRecord for checking whether a column with a given index is set. Also removed unnecessary unboxing of an Integer variable in the CSVRecord#isSet(String) method.