### PR TITLE
Fix CSV-149 and CSV-195

### DIFF
--- a/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
+++ b/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
@@ -125,7 +125,8 @@ final class ExtendedBufferedReader extends BufferedReader {
     @Override
     public int read() throws IOException {
         final int current = super.read();
-        if (current == CR || current == LF && lastChar != CR) {
+        if ((current == CR || current == LF && lastChar != CR)
+            || (current == END_OF_STREAM && lastChar != CR && lastChar != LF && lastChar != END_OF_STREAM)) {
             eolCounter++;
         }
         lastChar = current;

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -644,11 +644,11 @@ public class CSVParserTest {
             assertEquals(2, record.getRecordNumber());
             assertEquals(2, parser.getRecordNumber());
             assertNotNull(record = parser.nextRecord());
-            assertEquals(8, parser.getCurrentLineNumber());
+            assertEquals(9, parser.getCurrentLineNumber());
             assertEquals(3, record.getRecordNumber());
             assertEquals(3, parser.getRecordNumber());
             assertNull(record = parser.nextRecord());
-            assertEquals(8, parser.getCurrentLineNumber());
+            assertEquals(9, parser.getCurrentLineNumber());
             assertEquals(3, parser.getRecordNumber());
         }
     }
@@ -1192,11 +1192,11 @@ public class CSVParserTest {
             assertNotNull(parser.nextRecord());
             assertEquals(2, parser.getCurrentLineNumber());
             assertNotNull(parser.nextRecord());
-            // Still 2 because the last line is does not have EOL chars
-            assertEquals(2, parser.getCurrentLineNumber());
+            // Read EOF without EOL should 3
+            assertEquals(3, parser.getCurrentLineNumber());
             assertNull(parser.nextRecord());
-            // Still 2 because the last line is does not have EOL chars
-            assertEquals(2, parser.getCurrentLineNumber());
+            // Read EOF without EOL should 3
+            assertEquals(3, parser.getCurrentLineNumber());
         }
     }
 

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv149Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv149Test.java
@@ -24,10 +24,8 @@ import java.io.StringReader;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled
 public class JiraCsv149Test {
 
     private static final String CR_LF = "\r\n";


### PR DESCRIPTION
fix [CSV-195] and [CSV-149]
when stream end with normal char but not lineseparator will add 1 to currentlinenumber.

https://issues.apache.org/jira/browse/CSV-149
https://issues.apache.org/jira/browse/CSV-195
