### PR TITLE
Fix CSVFileParserTest.java to allow for a null return value from record.getComment()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,8 @@
             <exclude>src/test/resources/ferc.gov/transaction.txt</exclude>
             <exclude>src/test/resources/**/*.bin</exclude>
             <exclude>src/test/resources/CSV-259/sample.txt</exclude>
+            <exclude>src/test/resources/CSVFileParser/testCSV246.csv</exclude>
+            <exclude>src/test/resources/CSVFileParser/testCSV246_checkWithNoComment.txt</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -375,6 +377,8 @@
             <exclude>src/test/resources/ferc.gov/transaction.txt</exclude>
             <exclude>src/test/resources/**/*.bin</exclude>
             <exclude>src/test/resources/CSV-259/sample.txt</exclude>
+            <exclude>src/test/resources/CSVFileParser/testCSV246.csv</exclude>
+            <exclude>src/test/resources/CSVFileParser/testCSV246_checkWithNoComment.txt</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
@@ -93,8 +93,9 @@ public class CSVFileParserTest {
             try (final CSVParser parser = CSVParser.parse(new File(BASE, split[0]), Charset.defaultCharset(), format)) {
                 for (final CSVRecord record : parser) {
                     String parsed = Arrays.toString(record.values());
-                    if (checkComments && record.getComment() != null) {
-                        parsed += "#" + record.getComment().replace("\n", "\\n");
+                    String comment = record.getComment();
+                    if (checkComments && comment != null) {
+                        parsed += "#" + comment.replace("\n", "\\n");
                     }
                     final int count = record.size();
                     assertEquals(readTestData(testData), count + ":" + parsed, testFile.getName());
@@ -137,8 +138,9 @@ public class CSVFileParserTest {
             try (final CSVParser parser = CSVParser.parse(resource, Charset.forName("UTF-8"), format)) {
                 for (final CSVRecord record : parser) {
                     String parsed = Arrays.toString(record.values());
-                    if (checkComments && record.getComment() != null) {
-                        parsed += "#" + record.getComment().replace("\n", "\\n");
+                    String comment = record.getComment();
+                    if (checkComments && comment != null) {
+                        parsed += "#" + comment.replace("\n", "\\n");
                     }
                     final int count = record.size();
                     assertEquals(readTestData(testData), count + ":" + parsed, testFile.getName());

--- a/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
@@ -93,11 +93,8 @@ public class CSVFileParserTest {
             try (final CSVParser parser = CSVParser.parse(new File(BASE, split[0]), Charset.defaultCharset(), format)) {
                 for (final CSVRecord record : parser) {
                     String parsed = Arrays.toString(record.values());
-                    if (checkComments) {
-                        final String comment = record.getComment().replace("\n", "\\n");
-                        if (comment != null) {
-                            parsed += "#" + comment;
-                        }
+                    if (checkComments && record.getComment() != null) {
+                        parsed += "#" + record.getComment().replace("\n", "\\n");
                     }
                     final int count = record.size();
                     assertEquals(readTestData(testData), count + ":" + parsed, testFile.getName());
@@ -140,11 +137,8 @@ public class CSVFileParserTest {
             try (final CSVParser parser = CSVParser.parse(resource, Charset.forName("UTF-8"), format)) {
                 for (final CSVRecord record : parser) {
                     String parsed = Arrays.toString(record.values());
-                    if (checkComments) {
-                        final String comment = record.getComment().replace("\n", "\\n");
-                        if (comment != null) {
-                            parsed += "#" + comment;
-                        }
+                    if (checkComments && record.getComment() != null) {
+                        parsed += "#" + record.getComment().replace("\n", "\\n");
                     }
                     final int count = record.size();
                     assertEquals(readTestData(testData), count + ":" + parsed, testFile.getName());

--- a/src/test/resources/CSVFileParser/testCSV246.csv
+++ b/src/test/resources/CSVFileParser/testCSV246.csv
@@ -1,0 +1,8 @@
+a,b,c,e,f
+# Very Long
+# Comment 2
+g,h,i,j,k
+# Very Long
+
+# Comment 3
+l,m,n,o,p

--- a/src/test/resources/CSVFileParser/testCSV246_checkWithNoComment.txt
+++ b/src/test/resources/CSVFileParser/testCSV246_checkWithNoComment.txt
@@ -1,0 +1,10 @@
+testCSV246.csv CommentStart=# CheckComments
+Delimiter=<,> QuoteChar=<"> CommentStart=<#> SkipHeaderRecord:false
+5:[a, b, c, e, f]
+# Very Long
+# Comment 2
+5:[g, h, i, j, k]#Very Long\nComment 2
+# Very Long
+1:[]#Very Long
+# Comment 3
+5:[l, m, n, o, p]#Comment 3


### PR DESCRIPTION
The old test case record.getComment() will never be null and if record.getComment() be null the test code misplace the null test.
Add a new test file that record.getComment() will be null and test record.getComment() no null before using.