### PR TITLE
Fix null, emptyString, nullString

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -380,6 +380,10 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
 
     private final Token reusableToken = new Token();
 
+    private final String nullString;
+
+    private final boolean strictQuoteMode;
+
     /**
      * Customized CSV parser using the given {@link CSVFormat}
      *
@@ -430,6 +434,8 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         Objects.requireNonNull(format, "format");
 
         this.format = format;
+        this.nullString = this.format.getNullString();
+        this.strictQuoteMode = isStrictQuoteMode();
         this.lexer = new Lexer(format, new ExtendedBufferedReader(reader));
         this.csvRecordIterator = new CSVRecordIterator();
         final Headers headers = createHeaders();
@@ -445,8 +451,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         if (lastRecord && inputClean.isEmpty() && this.format.getTrailingDelimiter()) {
             return;
         }
-        final String nullString = this.format.getNullString();
-        this.recordList.add(inputClean.equals(nullString) ? null : inputClean);
+        this.recordList.add(handleNull(inputClean));
     }
 
     /**
@@ -635,12 +640,40 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     }
 
     /**
+     * Handle whether input is parsed as null
+     *
+     * @param input
+     *           the cell data to further processed
+     * @return null if input is parsed as null, or input itself if input isn't parsed as null
+     */
+    private String handleNull(String input) {
+        final boolean isQuoted = this.reusableToken.isQuoted;
+        if (input.equals(nullString)) {
+            // nullString = NULL(String), distinguish between "NULL" and NULL in ALL_NON_NULL or NON_NUMERIC quote mode
+            return (this.strictQuoteMode && isQuoted) ? input : null;
+        } else {
+            // don't set nullString, distingush between "" and ,,(absent values) in All_NON_NULL or NON_NUMERIC quote mode
+            return (this.strictQuoteMode && nullString == null && input.length() == 0 && !isQuoted) ? null : input;
+        }
+    }
+
+    /**
      * Gets whether this parser is closed.
      *
      * @return whether this parser is closed.
      */
     public boolean isClosed() {
         return this.lexer.isClosed();
+    }
+
+    /**
+     * Gets whether the format.quoteMode is ALL_NON_NULL or NON_NUMERIC
+     *
+     * @return true if format.quoteMode is equal to ALL_NON_NULL or format.quoteMode is equal to NON_NUMERIC
+     */
+    private boolean isStrictQuoteMode() {
+        return ((this.format.getQuoteMode() == QuoteMode.ALL_NON_NULL)
+                || (this.format.getQuoteMode() == QuoteMode.NON_NUMERIC));
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -275,6 +275,7 @@ final class Lexer implements Closeable {
      *             on invalid state: EOF before closing encapsulator or invalid character before delimiter or EOL
      */
     private Token parseEncapsulatedToken(final Token token) throws IOException {
+        token.isQuoted = true;
         // save current line number in case needed for IOE
         final long startLineNumber = getCurrentLineNumber();
         int c;

--- a/src/main/java/org/apache/commons/csv/Token.java
+++ b/src/main/java/org/apache/commons/csv/Token.java
@@ -55,10 +55,13 @@ final class Token {
     /** Token ready flag: indicates a valid token with content (ready for the parser). */
     boolean isReady;
 
+    boolean isQuoted;
+
     void reset() {
         content.setLength(0);
         type = INVALID;
         isReady = false;
+        isQuoted = false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -803,7 +803,7 @@ public class CSVPrinterTest {
         String expected = "\"NULL\"\tNULL\n";
         assertEquals(expected, writer.toString());
         String[] record0 = toFirstRecordValues(expected, format);
-        assertArrayEquals(new Object[2], record0);
+        assertArrayEquals(s, record0);
 
         s = new String[] { "\\N", null };
         format = CSVFormat.MYSQL.withNullString("\\N");

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv253Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv253Test.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.csv.issues;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Setting QuoteMode:ALL_NON_NULL or NON_NUMERIC can distinguish between empty string columns and absent value columns.
+ */
+public class JiraCsv253Test {
+
+    @Test
+    public void testHandleAbsentValues() throws IOException {
+        String source = "\"John\",,\"Doe\"\n" +
+                ",\"AA\",123\n" +
+                "\"John\",90,\n" +
+                "\"\",,90";
+        CSVFormat csvFormat = CSVFormat.DEFAULT.withQuoteMode(QuoteMode.NON_NUMERIC);
+        Iterator<CSVRecord> csvRecords = csvFormat.parse(new StringReader(source)).iterator();
+        assertArrayEqual(new String[]{"John", null, "Doe"}, csvRecords.next());
+        assertArrayEqual(new String[]{null, "AA", "123"}, csvRecords.next());
+        assertArrayEqual(new String[]{"John", "90", null}, csvRecords.next());
+        assertArrayEqual(new String[]{"", null, "90"}, csvRecords.next());
+    }
+
+    private void assertArrayEqual(String[] expected, CSVRecord actual) {
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], actual.get(i));
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv93Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv93Test.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.csv.issues;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Add more tests about null value.
+ * <p>
+ * QuoteMode:ALL_NON_NULL (Quotes all non-null fields, null will not be quoted but not null will be quoted). when
+ * withNullString("NULL"), NULL String value ("NULL") and null value (null) will be formatted as '"NULL",NULL'. So it
+ * also should be parsed as NULL String value and null value (["NULL", null]), It should be distinguish in parsing.
+ * And when don't set nullString in CSVFormat, String '"",' should be parsed as "" and null (["", null]) according to
+ * null will not be quoted but not null will be quoted.
+ * QuoteMode:NON_NUMERIC, same as ALL_NON_NULL.
+ * </p>
+ * <p>
+ * This can solve the problem of distinguishing between empty string columns and absent value columns which just like Jira
+ * CSV-253 to a certain extent
+ * </p>
+ */
+public class JiraCsv93Test {
+    private static Object[] objects1 = new Object[]{"abc", "", null, "a,b,c", 123};
+
+    private static Object[] objects2 = new Object[]{"abc", "NULL", null, "a,b,c", 123};
+
+    @Test
+    public void testWithNotSetNullString() throws IOException {
+        every(CSVFormat.DEFAULT,
+                objects1,
+                "abc,,,\"a,b,c\",123",
+                new String[]{"abc", "", "", "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withQuoteMode(QuoteMode.ALL),
+                objects1,
+                "\"abc\",\"\",,\"a,b,c\",\"123\"",
+                new String[]{"abc", "", "", "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withQuoteMode(QuoteMode.ALL_NON_NULL),
+                objects1,
+                "\"abc\",\"\",,\"a,b,c\",\"123\"",
+                new String[]{"abc", "", null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withQuoteMode(QuoteMode.MINIMAL),
+                objects1,
+                "abc,,,\"a,b,c\",123",
+                new String[]{"abc", "", "", "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withEscape('?').withQuoteMode(QuoteMode.NONE),
+                objects1,
+                "abc,,,a?,b?,c,123",
+                new String[]{"abc", "", "", "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withQuoteMode(QuoteMode.NON_NUMERIC),
+                objects1,
+                "\"abc\",\"\",,\"a,b,c\",123",
+                new String[]{"abc", "", null, "a,b,c", "123"});
+    }
+
+    @Test
+    public void testWithSetNullStringEmptyString() throws IOException {
+        every(CSVFormat.DEFAULT.withNullString(""),
+                objects1,
+                "abc,,,\"a,b,c\",123",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("").withQuoteMode(QuoteMode.ALL),
+                objects1,
+                "\"abc\",\"\",\"\",\"a,b,c\",\"123\"",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("").withQuoteMode(QuoteMode.ALL_NON_NULL),
+                objects1,
+                "\"abc\",\"\",,\"a,b,c\",\"123\"",
+                new String[]{"abc", "", null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("").withQuoteMode(QuoteMode.MINIMAL),
+                objects1,
+                "abc,,,\"a,b,c\",123",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("").withEscape('?').withQuoteMode(QuoteMode.NONE),
+                objects1,
+                "abc,,,a?,b?,c,123",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("").withQuoteMode(QuoteMode.NON_NUMERIC),
+                objects1,
+                "\"abc\",\"\",,\"a,b,c\",123",
+                new String[]{"abc", "", null, "a,b,c", "123"});
+    }
+
+    @Test
+    public void testWithSetNullStringNULL() throws IOException {
+        every(CSVFormat.DEFAULT.withNullString("NULL"),
+                objects2,
+                "abc,NULL,NULL,\"a,b,c\",123",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("NULL").withQuoteMode(QuoteMode.ALL),
+                objects2,
+                "\"abc\",\"NULL\",\"NULL\",\"a,b,c\",\"123\"",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("NULL").withQuoteMode(QuoteMode.ALL_NON_NULL),
+                objects2,
+                "\"abc\",\"NULL\",NULL,\"a,b,c\",\"123\"",
+                new String[]{"abc", "NULL", null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("NULL").withQuoteMode(QuoteMode.MINIMAL),
+                objects2,
+                "abc,NULL,NULL,\"a,b,c\",123",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("NULL").withEscape('?').withQuoteMode(QuoteMode.NONE),
+                objects2,
+                "abc,NULL,NULL,a?,b?,c,123",
+                new String[]{"abc", null, null, "a,b,c", "123"});
+        every(CSVFormat.DEFAULT.withNullString("NULL").withQuoteMode(QuoteMode.NON_NUMERIC),
+                objects2,
+                "\"abc\",\"NULL\",NULL,\"a,b,c\",123",
+                new String[]{"abc", "NULL", null, "a,b,c", "123"});
+    }
+
+    private void every(CSVFormat csvFormat, Object[] objects, String format, String[] data) throws IOException {
+        String source = csvFormat.format(objects);
+        assertEquals(format, csvFormat.format(objects));
+        CSVParser csvParser = csvFormat.parse(new StringReader(source));
+        CSVRecord csvRecord = csvParser.iterator().next();
+        for (int i = 0; i < data.length; i++) {
+            assertEquals(csvRecord.get(i), data[i]);
+        }
+    }
+}


### PR DESCRIPTION
* https://issues.apache.org/jira/projects/CSV/issues/CSV-93
* https://issues.apache.org/jira/projects/CSV/issues/CSV-253

When QuoteMode: ALL_NON_NULL (Quotes all non-null fields), we can distinguish null through it whether it is quoted. 
So ```"NULL",NULL``` should be parsed ```["NULL", null]```, but now it is parsed ```[null, null]```, when ```withNullString("NULL")```. And ```"",``` should be parsed ```["", null]```, but it is parsed ```["",""]```.
QuoteMode: NON_NUMERIC same as ALL_NON_NULL.

This PR can solve this problem. if user want to distinguish empty string and absent value, they can set QuoteMode to All_NON_NULL or NON_NUMERIC.