### PR TITLE
Update gitignore to ignore idea and vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-### https://raw.github.com/github/gitignore/14b7566ce157ce95b07006466bacee160f242284/maven.gitignore
+### https://github.com/github/gitignore/blob/master/Maven.gitignore
 
 target/
 pom.xml.tag
@@ -6,9 +6,18 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
 
 
-/.classpath
-/.project
-/.settings/
-/commons-csv.iml
+.classpath
+.project
+.settings/
+
+/.idea/
+*.iml
+
+/.vscode/


### PR DESCRIPTION
I'm about to rebase and respond to your feedback on https://github.com/apache/commons-csv/pull/114.
Just wanted to propose some minor changes, though.

### .gitignore
* Ignores all IntelliJ specific files. (What I was using before, so had some files left around still.)
* Ignores all Visual Studio Code specific files. (What I'm using now.)
* Replaces the dead link at the top of the file.

Edit: While I was at it, I opted to update the contents of .gitignore with the up-to-date revision on [github/gitignore](https://github.com/github/gitignore).

I can replace the link with `https://raw.githubusercontent.com/github/gitignore/6651bca9c83572f908474fc6206ed8a80df91290/Maven.gitignore` if preferred?
I prefer the current link, but whatever suits you.

### ~~.editorconfig~~
~~For those using code editors like Visual Studio Code, it can be easier if the project defines its preferences using [EditorConfig](https://editorconfig.org/) to override any program settings. (a vendor-agnostic configuration file that many code editors support)~~

~~I've just taken the EditorConfig configuration from the most starred Java project Apache has on GitHub:
https://github.com/apache/dubbo/blob/3.0/.editorconfig~~

~~It could be worth considering if you'd want to change anything about it, for example I think something like this might be better:~~
```
root = true

[*]
indent_style = space
indent_size = 2
end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true

# Preserve line breaks in Markdown
[*.md]
trim_trailing_whitespace = false

# 4 space indentation
[*.{java,xml}]
indent_size = 4
```

