### PR TITLE
CSV-279: Optimize Lexer Delimiter Check for One Character Delimiter

### DIFF
--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -123,6 +123,9 @@ final class Lexer implements Closeable {
         if (ch != delimiter[0]) {
             return false;
         }
+        if (delimiter.length == 1) {
+          return true;
+        }
         final int len = delimiter.length - 1;
         final char[] buf = reader.lookAhead(len);
         for (int i = 0; i < len; i++) {


### PR DESCRIPTION
If the delimiter is multiple characters, some amount of processing needs to happen to support it.  However, if the delimiter is a single character (common scenario), then the additional multi-byte processing (which are no-ops) can be skipped.


https://issues.apache.org/jira/browse/CSV-279

