### PR TITLE
CSV-282: Document and Automate CSV Benchmark Harness

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,0 +1,59 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+Apache Commons CSV Benchmark
+===================
+
+Apache Commons CSV includes a Java Microbenchmark Harness (JMH) for testing various implementations
+of CSV processing.
+
+Prerequisite
+-------------
+
+The Skife CSV implementation is not available in Maven Central and therefore must be manually
+installed into the local Maven repository. Run the falling script to download and install
+the JAR file (~1MB).
+
+```shell
+> ./benchmark-prereq.sh
+```
+
+Benchmarks
+-------------
+
+Benchmark Name  | CSV Parser      | Description
+--------------- | --------------- | -------------
+read            | Java JDK        | Use BufferedReader to perform a line count
+scan            | Java JDK        | Use Scanner to perform a line count
+split           | Java JDK        | Use BufferedReader to split each line on a delimiter
+parseCommonsCSV | commons-csv     | Use CSVFormat to split each line on a delimiter
+parseGenJavaCSV | generation-java | Use CsvReader to split each line on a delimiter
+parseJavaCSV    | java-csv        | Use CsvReader to split each line on a delimiter
+parseOpenCSV    | open-csv        | Use CSVReader to split each line on a delimiter
+parseSkifeCSV   | skife-csv       | Use CSVReader to split each line on a delimiter
+parseSuperCSV   | super-csv       | Use CsvListReader to split each line on a delimiter
+
+Running the Tests
+-------------
+
+```shell
+# Run all benchmark tests
+mvn test -Pbenchmark
+
+# Run a specific benchmark test
+mvn test -Pbenchmark -Dbenchmark=<name>
+```

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -29,7 +29,7 @@ installed into the local Maven repository. Run the falling script to download an
 the JAR file (~1MB).
 
 ```shell
-> ./benchmark-prereq.sh
+./benchmark-prereq.sh
 ```
 
 Benchmarks
@@ -56,4 +56,7 @@ mvn test -Pbenchmark
 
 # Run a specific benchmark test
 mvn test -Pbenchmark -Dbenchmark=<name>
+
+# Example of running basic "read" benchmark
+mvn test -Pbenchmark -Dbenchmark=read
 ```

--- a/benchmark-prereq.sh
+++ b/benchmark-prereq.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+##
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+wget -P /tmp https://kasparov.skife.org/csv/csv-1.0.jar
+
+mvn -version
+
+mvn install:install-file -Dfile=/tmp/csv-1.0.jar -DgroupId=org.skife.kasparov -DartifactId=csv -Dversion=1.0 -Dpackaging=jar
+

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,7 @@
           <groupId>org.skife.kasparov</groupId>
           <artifactId>csv</artifactId>
           <version>1.0</version>
+          <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I was able to get the CSV JMH benchmark running after parsing some notes left in the `pom.xml` files and fiddling around.  I have taken those notes, automated the process, and added some documentation for others to follow.