### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@
 language: java
 
 matrix:
+  fast_finish: true
   include:
     - jdk: openjdk8
     - jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,7 @@ script:
   - mvn
 after_success:
   - mvn -B -V clean test jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
