### PR TITLE
CSV-292: Add Automatic-Module-Name to JAR file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,24 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <archive combine.children="append">
+            <manifestEntries>
+              <Automatic-Module-Name>${commons.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes>


### PR DESCRIPTION
Ensure that the resulting Commons CSV JAR file can be used in JPMS based
projects

Prior to this change the JAR is missing the `Automatic-Module-Name` entry in its
manifest meaning it cannot be used in JPMS based projects (e.g. rvesse/airline#106) yielding errors like the following:

```
Error occurred during initialization of boot layer
java.lang.module.FindException: Module org.apache.commons.csv not found, required by com.github.rvesse.airline.examples
```

With this change JPMS based projects can successfully use Commons CSV without errors.