### PR TITLE
[CSV-300] Return new ArrayList in CSVRecord.toList() to prevent access to private values array

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -19,6 +19,7 @@ package org.apache.commons.csv;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -248,7 +249,8 @@ public final class CSVRecord implements Serializable, Iterable<String> {
     }
 
     /**
-     * Returns an iterator over the values of this record.
+     * Returns an iterator over the values of this record.<br>
+     * The iterator is read-only i.e. {@link Iterator#remove()} is not supported.
      *
      * @return an iterator over the values of this record.
      */
@@ -298,13 +300,13 @@ public final class CSVRecord implements Serializable, Iterable<String> {
     }
 
     /**
-     * Converts the values to a List.
+     * Returns the record's values as a read-only {@code List}.
      *
-     * @return a new List
+     * @return values as a new read-only {@code List}
      * @since 1.9.0
      */
     public List<String> toList() {
-        return Arrays.asList(values);
+        return Collections.unmodifiableList(Arrays.asList(values));
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -282,6 +282,13 @@ public class CSVRecordTest {
     }
 
     @Test
+    public void testToListReadOnly() {
+        assertFalse(record.toList().isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> record.toList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> record.iterator().remove());
+    }
+
+    @Test
     public void testToMap() {
         final Map<String, String> map = this.recordWithHeader.toMap();
         this.validateMap(map, true);


### PR DESCRIPTION
This PR offers a fix to bug CSV-300.