### PR TITLE
[CSV-301] Fix warnings (mostly deprecation) in unit tests

### DIFF
--- a/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFileParserTest.java
@@ -64,17 +64,17 @@ public class CSVFileParserTest {
             final String[] split = line.split(" ");
             assertTrue(split.length >= 1, testFile.getName() + " require 1 param");
             // first line starts with csv data file name
-            CSVFormat format = CSVFormat.newFormat(',').withQuote('"');
+            CSVFormat format = CSVFormat.newFormat(',').builder().setQuote('"').build();
             boolean checkComments = false;
             for (int i = 1; i < split.length; i++) {
                 final String option = split[i];
                 final String[] option_parts = option.split("=", 2);
                 if ("IgnoreEmpty".equalsIgnoreCase(option_parts[0])) {
-                    format = format.withIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1]));
+                    format = format.builder().setIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1])).build();
                 } else if ("IgnoreSpaces".equalsIgnoreCase(option_parts[0])) {
-                    format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1]));
+                    format = format.builder().setIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1])).build();
                 } else if ("CommentStart".equalsIgnoreCase(option_parts[0])) {
-                    format = format.withCommentMarker(option_parts[1].charAt(0));
+                    format = format.builder().setCommentMarker(option_parts[1].charAt(0)).build();
                 } else if ("CheckComments".equalsIgnoreCase(option_parts[0])) {
                     checkComments = true;
                 } else {
@@ -109,17 +109,17 @@ public class CSVFileParserTest {
             final String[] split = line.split(" ");
             assertTrue(split.length >= 1, testFile.getName() + " require 1 param");
             // first line starts with csv data file name
-            CSVFormat format = CSVFormat.newFormat(',').withQuote('"');
+            CSVFormat format = CSVFormat.newFormat(',').builder().setQuote('"').build();
             boolean checkComments = false;
             for (int i = 1; i < split.length; i++) {
                 final String option = split[i];
                 final String[] option_parts = option.split("=", 2);
                 if ("IgnoreEmpty".equalsIgnoreCase(option_parts[0])) {
-                    format = format.withIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1]));
+                    format = format.builder().setIgnoreEmptyLines(Boolean.parseBoolean(option_parts[1])).build();
                 } else if ("IgnoreSpaces".equalsIgnoreCase(option_parts[0])) {
-                    format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1]));
+                    format = format.builder().setIgnoreSurroundingSpaces(Boolean.parseBoolean(option_parts[1])).build();
                 } else if ("CommentStart".equalsIgnoreCase(option_parts[0])) {
-                    format = format.withCommentMarker(option_parts[1].charAt(0));
+                    format = format.builder().setCommentMarker(option_parts[1].charAt(0)).build();
                 } else if ("CheckComments".equalsIgnoreCase(option_parts[0])) {
                     checkComments = true;
                 } else {

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -67,7 +67,7 @@ public class CSVFormatTest {
     }
 
     private static CSVFormat copy(final CSVFormat format) {
-        return format.builder().setDelimiter(format.getDelimiter()).build();
+        return format.builder().setDelimiter(format.getDelimiterString()).build();
     }
 
     private void assertNotEquals(final String name, final String type, final Object left, final Object right) {
@@ -79,10 +79,9 @@ public class CSVFormatTest {
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testDelimiterSameAsCommentStartThrowsException_Deprecated() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter('!').withCommentMarker('!'));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setDelimiter('!').setCommentMarker('!').build());
     }
 
     @Test
@@ -90,10 +89,9 @@ public class CSVFormatTest {
         assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setDelimiter('!').setCommentMarker('!').build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testDelimiterSameAsEscapeThrowsException_Deprecated() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter('!').withEscape('!'));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setDelimiter('!').setEscape('!').build());
     }
 
     @Test
@@ -114,37 +112,33 @@ public class CSVFormatTest {
         assertArrayEquals(header, format.getHeader());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testDuplicateHeaderElements_Deprecated() {
         final String[] header = { "A", "A" };
-        final CSVFormat format = CSVFormat.DEFAULT.withHeader(header);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setHeader(header).build();
         assertEquals(2, format.getHeader().length);
         assertArrayEquals(header, format.getHeader());
     }
 
     @Test
     public void testDuplicateHeaderElementsFalse() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> CSVFormat.DEFAULT.builder().setAllowDuplicateHeaderNames(false).setHeader("A", "A").build());
+        assertThrows(IllegalArgumentException.class,
+            () -> CSVFormat.DEFAULT.builder().setDuplicateHeaderMode(DuplicateHeaderMode.ALLOW_EMPTY).setHeader("A", "A").build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testDuplicateHeaderElementsFalse_Deprecated() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> CSVFormat.DEFAULT.withAllowDuplicateHeaderNames(false).withHeader("A", "A"));
+                () -> CSVFormat.DEFAULT.builder().setDuplicateHeaderMode(DuplicateHeaderMode.ALLOW_EMPTY).setHeader("A", "A").build());
     }
 
     public void testDuplicateHeaderElementsTrue() {
-        CSVFormat.DEFAULT.builder().setAllowDuplicateHeaderNames(true).setHeader("A", "A").build();
+        CSVFormat.DEFAULT.builder().setDuplicateHeaderMode(DuplicateHeaderMode.ALLOW_ALL).setHeader("A", "A").build();
     }
 
-    @SuppressWarnings("deprecation")
     public void testDuplicateHeaderElementsTrue_Deprecated() {
-        CSVFormat.DEFAULT.withAllowDuplicateHeaderNames(true).withHeader("A", "A");
+        CSVFormat.DEFAULT.builder().setDuplicateHeaderMode(DuplicateHeaderMode.ALLOW_ALL).setHeader("A", "A");
     }
 
     @Test
@@ -177,15 +171,15 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsCommentStart_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withQuote('"')
-                .withCommentMarker('#')
-                .withQuoteMode(QuoteMode.ALL);
-        final CSVFormat left = right
-                .withCommentMarker('!');
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setQuote('"')
+                .setCommentMarker('#')
+                .setQuoteMode(QuoteMode.ALL)
+                .build();
+        final CSVFormat left = right.builder()
+                .setCommentMarker('!').build();
 
         assertNotEquals(right, left);
     }
@@ -213,16 +207,16 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsEscape_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withQuote('"')
-                .withCommentMarker('#')
-                .withEscape('+')
-                .withQuoteMode(QuoteMode.ALL);
-        final CSVFormat left = right
-                .withEscape('!');
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setQuote('"')
+                .setCommentMarker('#')
+                .setEscape('+')
+                .setQuoteMode(QuoteMode.ALL)
+                .build();
+        final CSVFormat left = right.builder()
+                .setEscape('!').build();
 
         assertNotEquals(right, left);
     }
@@ -298,20 +292,20 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsHeader_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withRecordSeparator(CR)
-                .withCommentMarker('#')
-                .withEscape('+')
-                .withHeader("One", "Two", "Three")
-                .withIgnoreEmptyLines()
-                .withIgnoreSurroundingSpaces()
-                .withQuote('"')
-                .withQuoteMode(QuoteMode.ALL);
-        final CSVFormat left = right
-                .withHeader("Three", "Two", "One");
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setRecordSeparator(CR)
+                .setCommentMarker('#')
+                .setEscape('+')
+                .setHeader("One", "Two", "Three")
+                .setIgnoreEmptyLines(true)
+                .setIgnoreSurroundingSpaces(true)
+                .setQuote('"')
+                .setQuoteMode(QuoteMode.ALL)
+                .build();
+        final CSVFormat left = right.builder()
+                .setHeader("Three", "Two", "One").build();
 
         assertNotEquals(right, left);
     }
@@ -333,18 +327,19 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsIgnoreEmptyLines_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withCommentMarker('#')
-                .withEscape('+')
-                .withIgnoreEmptyLines()
-                .withIgnoreSurroundingSpaces()
-                .withQuote('"')
-                .withQuoteMode(QuoteMode.ALL);
-        final CSVFormat left = right
-                .withIgnoreEmptyLines(false);
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setCommentMarker('#')
+                .setEscape('+')
+                .setIgnoreEmptyLines(true)
+                .setIgnoreSurroundingSpaces(true)
+                .setQuote('"')
+                .setQuoteMode(QuoteMode.ALL)
+                .build();
+        final CSVFormat left = right.builder()
+                .setIgnoreEmptyLines(false)
+                .build();
 
         assertNotEquals(right, left);
     }
@@ -365,17 +360,17 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsIgnoreSurroundingSpaces_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withCommentMarker('#')
-                .withEscape('+')
-                .withIgnoreSurroundingSpaces()
-                .withQuote('"')
-                .withQuoteMode(QuoteMode.ALL);
-        final CSVFormat left = right
-                .withIgnoreSurroundingSpaces(false);
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setCommentMarker('#')
+                .setEscape('+')
+                .setIgnoreSurroundingSpaces(true)
+                .setQuote('"')
+                .setQuoteMode(QuoteMode.ALL)
+                .build();
+        final CSVFormat left = right.builder()
+                .setIgnoreSurroundingSpaces(false).build();
 
         assertNotEquals(right, left);
     }
@@ -388,11 +383,10 @@ public class CSVFormatTest {
         assertNotEquals(left, right);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsLeftNoQuoteRightQuote_Deprecated() {
-        final CSVFormat left = CSVFormat.newFormat(',').withQuote(null);
-        final CSVFormat right = left.withQuote('#');
+        final CSVFormat left = CSVFormat.newFormat(',').builder().setQuote(null).build();
+        final CSVFormat right = left.builder().setQuote('#').build();
 
         assertNotEquals(left, right);
     }
@@ -405,11 +399,10 @@ public class CSVFormatTest {
         assertEquals(left, right);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsNoQuotes_Deprecated() {
-        final CSVFormat left = CSVFormat.newFormat(',').withQuote(null);
-        final CSVFormat right = left.withQuote(null);
+        final CSVFormat left = CSVFormat.newFormat(',').builder().setQuote(null).build();
+        final CSVFormat right = left.builder().setQuote(null).build();
 
         assertEquals(left, right);
     }
@@ -433,20 +426,20 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsNullString_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withRecordSeparator(CR)
-                .withCommentMarker('#')
-                .withEscape('+')
-                .withIgnoreEmptyLines()
-                .withIgnoreSurroundingSpaces()
-                .withQuote('"')
-                .withQuoteMode(QuoteMode.ALL)
-                .withNullString("null");
-        final CSVFormat left = right
-                .withNullString("---");
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setRecordSeparator(CR)
+                .setCommentMarker('#')
+                .setEscape('+')
+                .setIgnoreEmptyLines(true)
+                .setIgnoreSurroundingSpaces(true)
+                .setQuote('"')
+                .setQuoteMode(QuoteMode.ALL)
+                .setNullString("null")
+                .build();
+        final CSVFormat left = right.builder()
+                .setNullString("---").build();
 
         assertNotEquals(right, left);
     }
@@ -470,7 +463,7 @@ public class CSVFormatTest {
         assertFalse(csvFormatOne.isCommentMarkerSet());
         assertTrue(csvFormatOne.isQuoteCharacterSet());
 
-        assertEquals('|', csvFormatOne.getDelimiter());
+        assertEquals("|", csvFormatOne.getDelimiterString());
         assertFalse(csvFormatOne.getAllowMissingColumnNames());
 
         assertTrue(csvFormatOne.isEscapeCharacterSet());
@@ -492,7 +485,7 @@ public class CSVFormatTest {
         assertFalse(csvFormatTwo.getAllowMissingColumnNames());
         assertEquals(QuoteMode.ALL_NON_NULL, csvFormatTwo.getQuoteMode());
 
-        assertEquals('\t', csvFormatTwo.getDelimiter());
+        assertEquals("\t", csvFormatTwo.getDelimiterString());
         assertEquals("\n", csvFormatTwo.getRecordSeparator());
 
         assertFalse(csvFormatTwo.isQuoteCharacterSet());
@@ -528,7 +521,7 @@ public class CSVFormatTest {
         assertFalse(csvFormatOne.isCommentMarkerSet());
         assertTrue(csvFormatOne.isQuoteCharacterSet());
 
-        assertEquals('|', csvFormatOne.getDelimiter());
+        assertEquals("|", csvFormatOne.getDelimiterString());
         assertFalse(csvFormatOne.getAllowMissingColumnNames());
 
         assertTrue(csvFormatOne.isEscapeCharacterSet());
@@ -549,7 +542,7 @@ public class CSVFormatTest {
         assertFalse(csvFormatTwo.getAllowMissingColumnNames());
         assertEquals(QuoteMode.ALL_NON_NULL, csvFormatTwo.getQuoteMode());
 
-        assertEquals('\t', csvFormatTwo.getDelimiter());
+        assertEquals("\t", csvFormatTwo.getDelimiterString());
         assertEquals("\n", csvFormatTwo.getRecordSeparator());
 
         assertFalse(csvFormatTwo.isQuoteCharacterSet());
@@ -588,11 +581,10 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsQuoteChar_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'').withQuote('"');
-        final CSVFormat left = right.withQuote('!');
+        final CSVFormat right = CSVFormat.newFormat('\'').builder().setQuote('"').build();
+        final CSVFormat left = right.builder().setQuote('!').build();
 
         assertNotEquals(right, left);
     }
@@ -610,14 +602,15 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsQuotePolicy_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withQuote('"')
-                .withQuoteMode(QuoteMode.ALL);
-        final CSVFormat left = right
-                .withQuoteMode(QuoteMode.MINIMAL);
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setQuote('"')
+                .setQuoteMode(QuoteMode.ALL)
+                .build();
+        final CSVFormat left = right.builder()
+                .setQuoteMode(QuoteMode.MINIMAL)
+                .build();
 
         assertNotEquals(right, left);
     }
@@ -640,19 +633,19 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsRecordSeparator_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withRecordSeparator(CR)
-                .withCommentMarker('#')
-                .withEscape('+')
-                .withIgnoreEmptyLines()
-                .withIgnoreSurroundingSpaces()
-                .withQuote('"')
-                .withQuoteMode(QuoteMode.ALL);
-        final CSVFormat left = right
-                .withRecordSeparator(LF);
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setRecordSeparator(CR)
+                .setCommentMarker('#')
+                .setEscape('+')
+                .setIgnoreEmptyLines(true)
+                .setIgnoreSurroundingSpaces(true)
+                .setQuote('"')
+                .setQuoteMode(QuoteMode.ALL)
+                .build();
+        final CSVFormat left = right.builder()
+                .setRecordSeparator(LF).build();
 
         assertNotEquals(right, left);
     }
@@ -676,21 +669,21 @@ public class CSVFormatTest {
         assertNotEquals(right, left);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEqualsSkipHeaderRecord_Deprecated() {
-        final CSVFormat right = CSVFormat.newFormat('\'')
-                .withRecordSeparator(CR)
-                .withCommentMarker('#')
-                .withEscape('+')
-                .withIgnoreEmptyLines()
-                .withIgnoreSurroundingSpaces()
-                .withQuote('"')
-                .withQuoteMode(QuoteMode.ALL)
-                .withNullString("null")
-                .withSkipHeaderRecord();
-        final CSVFormat left = right
-                .withSkipHeaderRecord(false);
+        final CSVFormat right = CSVFormat.newFormat('\'').builder()
+                .setRecordSeparator(CR)
+                .setCommentMarker('#')
+                .setEscape('+')
+                .setIgnoreEmptyLines(true)
+                .setIgnoreSurroundingSpaces(true)
+                .setQuote('"')
+                .setQuoteMode(QuoteMode.ALL)
+                .setNullString("null")
+                .setSkipHeaderRecord(true)
+                .build();
+        final CSVFormat left = right.builder()
+                .setSkipHeaderRecord(false).build();
 
         assertNotEquals(right, left);
     }
@@ -718,7 +711,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getAllowMissingColumnNames());
         assertEquals(QuoteMode.ALL_NON_NULL, csvFormat.getQuoteMode());
 
-        assertEquals('\t', csvFormat.getDelimiter());
+        assertEquals("\t", csvFormat.getDelimiterString());
         assertFalse(csvFormat.getSkipHeaderRecord());
 
         assertEquals("\n", csvFormat.getRecordSeparator());
@@ -745,7 +738,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getAllowMissingColumnNames());
         assertEquals(QuoteMode.ALL_NON_NULL, csvFormat.getQuoteMode());
 
-        assertEquals('\t', csvFormat.getDelimiter());
+        assertEquals("\t", csvFormat.getDelimiterString());
         assertFalse(csvFormat.getSkipHeaderRecord());
 
         assertEquals("\n", csvFormat.getRecordSeparator());
@@ -763,10 +756,9 @@ public class CSVFormatTest {
         assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setEscape('!').setCommentMarker('!').build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEscapeSameAsCommentStartThrowsException_Deprecated() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withEscape('!').withCommentMarker('!'));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setEscape('!').setCommentMarker('!').build());
     }
 
     @Test
@@ -777,13 +769,11 @@ public class CSVFormatTest {
                 () -> CSVFormat.DEFAULT.builder().setEscape(Character.valueOf('!')).setCommentMarker(Character.valueOf('!')).build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testEscapeSameAsCommentStartThrowsExceptionForWrapperType_Deprecated() {
         // Cannot assume that callers won't use different Character objects
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> CSVFormat.DEFAULT.withEscape(Character.valueOf('!')).withCommentMarker(Character.valueOf('!')));
+        assertThrows(IllegalArgumentException.class,
+                () -> CSVFormat.DEFAULT.builder().setEscape(Character.valueOf('!')).setCommentMarker(Character.valueOf('!')).build());
     }
 
     @Test
@@ -806,10 +796,11 @@ public class CSVFormatTest {
 
     @Test
     public void testFormatToString() {
-        final CSVFormat format = CSVFormat.RFC4180.withEscape('?').withDelimiter(',')
-                .withQuoteMode(QuoteMode.MINIMAL).withRecordSeparator(CRLF).withQuote('"')
-                .withNullString("").withIgnoreHeaderCase(true)
-                .withHeaderComments("This is HeaderComments").withHeader("col1","col2","col3");
+        final CSVFormat format = CSVFormat.RFC4180.builder().setEscape('?').setDelimiter(',')
+                .setQuoteMode(QuoteMode.MINIMAL).setRecordSeparator(CRLF).setQuote('"')
+                .setNullString("").setIgnoreHeaderCase(true)
+                .setHeaderComments("This is HeaderComments").setHeader("col1","col2","col3")
+                .build();
         assertEquals("Delimiter=<,> Escape=<?> QuoteChar=<\"> QuoteMode=<MINIMAL> NullString=<> RecordSeparator=<" +CRLF+
                 "> IgnoreHeaderCase:ignored SkipHeaderRecord:false HeaderComments:[This is HeaderComments] Header:[col1, col2, col3]", format.toString());
     }
@@ -817,7 +808,7 @@ public class CSVFormatTest {
     @Test
     public void testGetHeader() {
         final String[] header = {"one", "two", "three"};
-        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.withHeader(header);
+        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.builder().setHeader(header).build();
         // getHeader() makes a copy of the header array.
         final String[] headerCopy = formatWithHeader.getHeader();
         headerCopy[0] = "A";
@@ -831,7 +822,7 @@ public class CSVFormatTest {
     public void testHashCodeAndWithIgnoreHeaderCase() {
 
         final CSVFormat csvFormat = CSVFormat.INFORMIX_UNLOAD_CSV;
-        final CSVFormat csvFormatTwo = csvFormat.withIgnoreHeaderCase();
+        final CSVFormat csvFormatTwo = csvFormat.builder().setIgnoreHeaderCase(true).build();
         csvFormatTwo.hashCode();
 
         assertFalse(csvFormat.getIgnoreHeaderCase());
@@ -847,13 +838,12 @@ public class CSVFormatTest {
 
     @Test
     public void testJiraCsv236() {
-        CSVFormat.DEFAULT.builder().setAllowDuplicateHeaderNames(true).setHeader("CC","VV","VV").build();
+        CSVFormat.DEFAULT.builder().setDuplicateHeaderMode(DuplicateHeaderMode.ALLOW_ALL).setHeader("CC","VV","VV").build();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testJiraCsv236__Deprecated() {
-        CSVFormat.DEFAULT.withAllowDuplicateHeaderNames().withHeader("CC","VV","VV");
+        CSVFormat.DEFAULT.builder().setDuplicateHeaderMode(DuplicateHeaderMode.ALLOW_ALL).setHeader("CC","VV","VV");
     }
 
     @Test
@@ -879,7 +869,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getIgnoreSurroundingSpaces());
         assertFalse(csvFormat.getTrailingDelimiter());
 
-        assertEquals('X', csvFormat.getDelimiter());
+        assertEquals("X", csvFormat.getDelimiterString());
         assertNull(csvFormat.getNullString());
 
         assertFalse(csvFormat.isQuoteCharacterSet());
@@ -906,7 +896,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getIgnoreSurroundingSpaces());
         assertFalse(csvFormat.getTrailingDelimiter());
 
-        assertEquals('X', csvFormat.getDelimiter());
+        assertEquals("X", csvFormat.getDelimiterString());
         assertNull(csvFormat.getNullString());
 
         assertFalse(csvFormat.isQuoteCharacterSet());
@@ -925,10 +915,9 @@ public class CSVFormatTest {
         assertFalse(formatStr.endsWith("null"));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testNullRecordSeparatorCsv106__Deprecated() {
-        final CSVFormat format = CSVFormat.newFormat(';').withSkipHeaderRecord().withHeader("H1", "H2");
+        final CSVFormat format = CSVFormat.newFormat(';').builder().setSkipHeaderRecord(true).setHeader("H1", "H2").build();
         final String formatStr = format.format("A", "B");
         assertNotNull(formatStr);
         assertFalse(formatStr.endsWith("null"));
@@ -938,7 +927,7 @@ public class CSVFormatTest {
     public void testPrintWithEscapesEndWithCRLF() throws IOException {
         final Reader in = new StringReader("x,y,x\r\na,?b,c\r\n");
         final Appendable out = new StringBuilder();
-        final CSVFormat format = CSVFormat.RFC4180.withEscape('?').withDelimiter(',').withQuote(null).withRecordSeparator(CRLF);
+        final CSVFormat format = CSVFormat.RFC4180.builder().setEscape('?').setDelimiter(',').setQuote(null).setRecordSeparator(CRLF).build();
         format.print(in,out,true);
         assertEquals("x?,y?,x?r?na?,??b?,c?r?n", out.toString());
     }
@@ -947,7 +936,7 @@ public class CSVFormatTest {
     public void testPrintWithEscapesEndWithoutCRLF() throws IOException {
         final Reader in = new StringReader("x,y,x");
         final Appendable out = new StringBuilder();
-        final CSVFormat format = CSVFormat.RFC4180.withEscape('?').withDelimiter(',').withQuote(null).withRecordSeparator(CRLF);
+        final CSVFormat format = CSVFormat.RFC4180.builder().setEscape('?').setDelimiter(',').setQuote(null).setRecordSeparator(CRLF).build();
         format.print(in,out,true);
         assertEquals("x?,y?,x", out.toString());
     }
@@ -956,7 +945,7 @@ public class CSVFormatTest {
     public void testPrintWithoutQuotes() throws IOException {
         final Reader in = new StringReader("");
         final Appendable out = new StringBuilder();
-        final CSVFormat format = CSVFormat.RFC4180.withDelimiter(',').withQuote('"').withEscape('?').withQuoteMode(QuoteMode.NON_NUMERIC);
+        final CSVFormat format = CSVFormat.RFC4180.builder().setDelimiter(',').setQuote('"').setEscape('?').setQuoteMode(QuoteMode.NON_NUMERIC).build();
         format.print(in, out, true);
         assertEquals("\"\"", out.toString());
     }
@@ -965,7 +954,7 @@ public class CSVFormatTest {
     public void testPrintWithQuoteModeIsNONE() throws IOException {
         final Reader in = new StringReader("a,b,c");
         final Appendable out = new StringBuilder();
-        final CSVFormat format = CSVFormat.RFC4180.withDelimiter(',').withQuote('"').withEscape('?').withQuoteMode(QuoteMode.NONE);
+        final CSVFormat format = CSVFormat.RFC4180.builder().setDelimiter(',').setQuote('"').setEscape('?').setQuoteMode(QuoteMode.NONE).build();
         format.print(in, out, true);
         assertEquals("a?,b?,c", out.toString());
     }
@@ -974,7 +963,7 @@ public class CSVFormatTest {
     public void testPrintWithQuotes() throws IOException {
         final Reader in = new StringReader("\"a,b,c\r\nx,y,z");
         final Appendable out = new StringBuilder();
-        final CSVFormat format = CSVFormat.RFC4180.withDelimiter(',').withQuote('"').withEscape('?').withQuoteMode(QuoteMode.NON_NUMERIC);
+        final CSVFormat format = CSVFormat.RFC4180.builder().setDelimiter(',').setQuote('"').setEscape('?').setQuoteMode(QuoteMode.NON_NUMERIC).build();
         format.print(in, out, true);
         assertEquals("\"\"\"a,b,c\r\nx,y,z\"", out.toString());
     }
@@ -984,10 +973,9 @@ public class CSVFormatTest {
         assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setQuote('!').setCommentMarker('!').build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testQuoteCharSameAsCommentStartThrowsException_Deprecated() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withQuote('!').withCommentMarker('!'));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setQuote('!').setCommentMarker('!').build());
     }
 
     @Test
@@ -998,13 +986,12 @@ public class CSVFormatTest {
                 () -> CSVFormat.DEFAULT.builder().setQuote(Character.valueOf('!')).setCommentMarker('!').build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testQuoteCharSameAsCommentStartThrowsExceptionForWrapperType_Deprecated() {
         // Cannot assume that callers won't use different Character objects
         assertThrows(
                 IllegalArgumentException.class,
-                () -> CSVFormat.DEFAULT.withQuote(Character.valueOf('!')).withCommentMarker('!'));
+                () -> CSVFormat.DEFAULT.builder().setQuote(Character.valueOf('!')).setCommentMarker('!').build());
     }
 
     @Test
@@ -1012,10 +999,9 @@ public class CSVFormatTest {
         assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setQuote('!').setDelimiter('!').build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testQuoteCharSameAsDelimiterThrowsException_Deprecated() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withQuote('!').withDelimiter('!'));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setQuote('!').setDelimiter('!').build());
     }
 
     @Test
@@ -1023,16 +1009,15 @@ public class CSVFormatTest {
         assertThrows(IllegalArgumentException.class, () -> CSVFormat.newFormat('!').builder().setQuoteMode(QuoteMode.NONE).build());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testQuotePolicyNoneWithoutEscapeThrowsException_Deprecated() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.newFormat('!').withQuoteMode(QuoteMode.NONE));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.newFormat('!').builder().setQuoteMode(QuoteMode.NONE).build());
     }
 
     @Test
     public void testRFC4180() {
         assertNull(RFC4180.getCommentMarker());
-        assertEquals(',', RFC4180.getDelimiter());
+        assertEquals(",", RFC4180.getDelimiterString());
         assertNull(RFC4180.getEscapeCharacter());
         assertFalse(RFC4180.getIgnoreEmptyLines());
         assertEquals(Character.valueOf('"'), RFC4180.getQuoteCharacter());
@@ -1054,7 +1039,7 @@ public class CSVFormatTest {
         final CSVFormat format = (CSVFormat) in.readObject();
 
         assertNotNull(format);
-        assertEquals(CSVFormat.DEFAULT.getDelimiter(), format.getDelimiter(), "delimiter");
+        assertEquals(CSVFormat.DEFAULT.getDelimiterString(), format.getDelimiterString(), "delimiter");
         assertEquals(CSVFormat.DEFAULT.getQuoteCharacter(), format.getQuoteCharacter(), "encapsulator");
         assertEquals(CSVFormat.DEFAULT.getCommentMarker(), format.getCommentMarker(), "comment start");
         assertEquals(CSVFormat.DEFAULT.getRecordSeparator(), format.getRecordSeparator(), "record separator");
@@ -1085,7 +1070,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getIgnoreSurroundingSpaces());
 
         assertFalse(csvFormat.getTrailingDelimiter());
-        assertEquals(',', csvFormat.getDelimiter());
+        assertEquals(",", csvFormat.getDelimiterString());
 
         assertFalse(csvFormat.getIgnoreHeaderCase());
         assertEquals("\r\n", csvFormat.getRecordSeparator());
@@ -1107,7 +1092,7 @@ public class CSVFormatTest {
 
         final Character character = Character.valueOf('n');
 
-        final CSVFormat csvFormatTwo = csvFormat.withCommentMarker(character);
+        final CSVFormat csvFormatTwo = csvFormat.builder().setCommentMarker(character).build();
 
         assertNull(csvFormat.getEscapeCharacter());
         assertTrue(csvFormat.isQuoteCharacterSet());
@@ -1116,7 +1101,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getIgnoreSurroundingSpaces());
 
         assertFalse(csvFormat.getTrailingDelimiter());
-        assertEquals(',', csvFormat.getDelimiter());
+        assertEquals(",", csvFormat.getDelimiterString());
 
         assertFalse(csvFormat.getIgnoreHeaderCase());
         assertEquals("\r\n", csvFormat.getRecordSeparator());
@@ -1142,7 +1127,7 @@ public class CSVFormatTest {
         assertEquals('\"', (char)csvFormatTwo.getQuoteCharacter());
         assertNull(csvFormatTwo.getNullString());
 
-        assertEquals(',', csvFormatTwo.getDelimiter());
+        assertEquals(",", csvFormatTwo.getDelimiterString());
         assertFalse(csvFormatTwo.getTrailingDelimiter());
 
         assertTrue(csvFormatTwo.isCommentMarkerSet());
@@ -1175,7 +1160,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getIgnoreSurroundingSpaces());
 
         assertFalse(csvFormat.getTrailingDelimiter());
-        assertEquals(',', csvFormat.getDelimiter());
+        assertEquals(",", csvFormat.getDelimiterString());
 
         assertFalse(csvFormat.getIgnoreHeaderCase());
         assertEquals("\r\n", csvFormat.getRecordSeparator());
@@ -1201,7 +1186,7 @@ public class CSVFormatTest {
         assertEquals('\"', (char)csvFormatTwo.getQuoteCharacter());
         assertNull(csvFormatTwo.getNullString());
 
-        assertEquals(',', csvFormatTwo.getDelimiter());
+        assertEquals(",", csvFormatTwo.getDelimiterString());
         assertFalse(csvFormatTwo.getTrailingDelimiter());
 
         assertTrue(csvFormatTwo.isCommentMarkerSet());
@@ -1236,7 +1221,8 @@ public class CSVFormatTest {
 
     @Test
     public void testTrim() throws IOException {
-        final CSVFormat formatWithTrim = CSVFormat.DEFAULT.withDelimiter(',').withTrim().withQuote(null).withRecordSeparator(CRLF);
+        final CSVFormat formatWithTrim = CSVFormat.DEFAULT.builder().setDelimiter(',').setTrim(true)
+                .setQuote(null).setRecordSeparator(CRLF).build();
 
         CharSequence in = "a,b,c";
         final StringBuilder out = new StringBuilder();
@@ -1261,40 +1247,40 @@ public class CSVFormatTest {
 
     @Test
     public void testWithCommentStart() {
-        final CSVFormat formatWithCommentStart = CSVFormat.DEFAULT.withCommentMarker('#');
+        final CSVFormat formatWithCommentStart = CSVFormat.DEFAULT.builder().setCommentMarker('#').build();
         assertEquals( Character.valueOf('#'), formatWithCommentStart.getCommentMarker());
     }
 
 
     @Test
     public void testWithCommentStartCRThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withCommentMarker(CR));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setCommentMarker(CR));
     }
 
 
     @Test
     public void testWithDelimiter() {
-        final CSVFormat formatWithDelimiter = CSVFormat.DEFAULT.withDelimiter('!');
-        assertEquals('!', formatWithDelimiter.getDelimiter());
+        final CSVFormat formatWithDelimiter = CSVFormat.DEFAULT.builder().setDelimiter('!').build();
+        assertEquals("!", formatWithDelimiter.getDelimiterString());
     }
 
 
     @Test
     public void testWithDelimiterLFThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter(LF));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setDelimiter(LF));
     }
 
 
     @Test
     public void testWithEmptyEnum() {
-        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.withHeader(EmptyEnum.class);
+        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.builder().setHeader(EmptyEnum.class).build();
         assertEquals(0, formatWithHeader.getHeader().length);
     }
 
 
     @Test
     public void testWithEscape() {
-        final CSVFormat formatWithEscape = CSVFormat.DEFAULT.withEscape('&');
+        final CSVFormat formatWithEscape = CSVFormat.DEFAULT.builder().setEscape('&').build();
         assertEquals(Character.valueOf('&'), formatWithEscape.getEscapeCharacter());
     }
 
@@ -1305,18 +1291,21 @@ public class CSVFormatTest {
             CSVFormat.DEFAULT.builder().setDuplicateHeaderMode(DuplicateHeaderMode.ALLOW_EMPTY).build();
 
         assertEquals(DuplicateHeaderMode.ALLOW_EMPTY, formatWithEmptyDuplicates.getDuplicateHeaderMode());
-        assertFalse(formatWithEmptyDuplicates.getAllowDuplicateHeaderNames());
+        assertFalse(formatWithEmptyDuplicates.getDuplicateHeaderMode() == DuplicateHeaderMode.ALLOW_ALL);
     }
 
     @Test
     public void testWithEscapeCRThrowsExceptions() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withEscape(CR));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setEscape(CR));
     }
 
 
     @Test
     public void testWithFirstRecordAsHeader() {
-        final CSVFormat formatWithFirstRecordAsHeader = CSVFormat.DEFAULT.withFirstRecordAsHeader();
+        final CSVFormat formatWithFirstRecordAsHeader = CSVFormat.DEFAULT.builder()
+            .setHeader()
+            .setSkipHeaderRecord(true)
+            .build();
         assertTrue(formatWithFirstRecordAsHeader.getSkipHeaderRecord());
         assertEquals(0, formatWithFirstRecordAsHeader.getHeader().length);
     }
@@ -1325,7 +1314,7 @@ public class CSVFormatTest {
     public void testWithHeader() {
         final String[] header = {"one", "two", "three"};
         // withHeader() makes a copy of the header array.
-        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.withHeader(header);
+        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.builder().setHeader(header).build();
         assertArrayEquals(header, formatWithHeader.getHeader());
         assertNotSame(header, formatWithHeader.getHeader());
     }
@@ -1344,7 +1333,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getSkipHeaderRecord());
         assertNull(csvFormat.getQuoteMode());
 
-        assertEquals(',', csvFormat.getDelimiter());
+        assertEquals(",", csvFormat.getDelimiterString());
         assertTrue(csvFormat.getIgnoreEmptyLines());
 
         assertFalse(csvFormat.getIgnoreHeaderCase());
@@ -1363,8 +1352,7 @@ public class CSVFormatTest {
         assertNull(csvFormat.getEscapeCharacter());
 
         final Object[] objectArray = new Object[8];
-        final CSVFormat csvFormatTwo = csvFormat.withHeaderComments(objectArray);
-
+        final CSVFormat csvFormatTwo = csvFormat.builder().setHeaderComments(objectArray).build();
         assertEquals('\"', (char)csvFormat.getQuoteCharacter());
         assertFalse(csvFormat.isCommentMarkerSet());
 
@@ -1374,7 +1362,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getSkipHeaderRecord());
         assertNull(csvFormat.getQuoteMode());
 
-        assertEquals(',', csvFormat.getDelimiter());
+        assertEquals(",", csvFormat.getDelimiterString());
         assertTrue(csvFormat.getIgnoreEmptyLines());
 
         assertFalse(csvFormat.getIgnoreHeaderCase());
@@ -1414,7 +1402,7 @@ public class CSVFormatTest {
         assertFalse(csvFormatTwo.getTrailingDelimiter());
 
         assertEquals("\r\n", csvFormatTwo.getRecordSeparator());
-        assertEquals(',', csvFormatTwo.getDelimiter());
+        assertEquals(",", csvFormatTwo.getDelimiterString());
 
         assertNull(csvFormatTwo.getCommentMarker());
         assertFalse(csvFormatTwo.isCommentMarkerSet());
@@ -1435,7 +1423,7 @@ public class CSVFormatTest {
         assertFalse(csvFormat.getSkipHeaderRecord());
         assertNull(csvFormat.getQuoteMode());
 
-        assertEquals(',', csvFormat.getDelimiter());
+        assertEquals(",", csvFormat.getDelimiterString());
         assertTrue(csvFormat.getIgnoreEmptyLines());
 
         assertFalse(csvFormat.getIgnoreHeaderCase());
@@ -1475,7 +1463,7 @@ public class CSVFormatTest {
         assertFalse(csvFormatTwo.getTrailingDelimiter());
 
         assertEquals("\r\n", csvFormatTwo.getRecordSeparator());
-        assertEquals(',', csvFormatTwo.getDelimiter());
+        assertEquals(",", csvFormatTwo.getDelimiterString());
 
         assertNull(csvFormatTwo.getCommentMarker());
         assertFalse(csvFormatTwo.isCommentMarkerSet());
@@ -1493,7 +1481,7 @@ public class CSVFormatTest {
 
     @Test
     public void testWithHeaderEnum() {
-        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.withHeader(Header.class);
+        final CSVFormat formatWithHeader = CSVFormat.DEFAULT.builder().setHeader(Header.class).build();
         assertArrayEquals(new String[]{ "Name", "Email", "Phone" }, formatWithHeader.getHeader());
     }
 
@@ -1501,72 +1489,72 @@ public class CSVFormatTest {
     public void testWithHeaderEnumNull() {
         final CSVFormat format =  CSVFormat.DEFAULT;
         final Class<Enum<?>> simpleName = null;
-        format.withHeader(simpleName);
+        format.builder().setHeader(simpleName).build();
     }
 
     @Test
     public  void testWithHeaderResultSetNull() throws SQLException {
         final CSVFormat format = CSVFormat.DEFAULT;
         final ResultSet resultSet = null;
-        format.withHeader(resultSet);
+        format.builder().setHeader(resultSet).build();
     }
 
     @Test
     public void testWithIgnoreEmptyLines() {
-        assertFalse(CSVFormat.DEFAULT.withIgnoreEmptyLines(false).getIgnoreEmptyLines());
-        assertTrue(CSVFormat.DEFAULT.withIgnoreEmptyLines().getIgnoreEmptyLines());
+        assertFalse(CSVFormat.DEFAULT.builder().setIgnoreEmptyLines(false).build().getIgnoreEmptyLines());
+        assertTrue(CSVFormat.DEFAULT.builder().setIgnoreEmptyLines(true).build().getIgnoreEmptyLines());
     }
 
     @Test
     public void testWithIgnoreSurround() {
-        assertFalse(CSVFormat.DEFAULT.withIgnoreSurroundingSpaces(false).getIgnoreSurroundingSpaces());
-        assertTrue(CSVFormat.DEFAULT.withIgnoreSurroundingSpaces().getIgnoreSurroundingSpaces());
+        assertFalse(CSVFormat.DEFAULT.builder().setIgnoreSurroundingSpaces(false).build().getIgnoreSurroundingSpaces());
+        assertTrue(CSVFormat.DEFAULT.builder().setIgnoreSurroundingSpaces(true).build().getIgnoreSurroundingSpaces());
     }
 
     @Test
     public void testWithNullString() {
-        final CSVFormat formatWithNullString = CSVFormat.DEFAULT.withNullString("null");
+        final CSVFormat formatWithNullString = CSVFormat.DEFAULT.builder().setNullString("null").build();
         assertEquals("null", formatWithNullString.getNullString());
     }
 
     @Test
     public void testWithQuoteChar() {
-        final CSVFormat formatWithQuoteChar = CSVFormat.DEFAULT.withQuote('"');
+        final CSVFormat formatWithQuoteChar = CSVFormat.DEFAULT.builder().setQuote('"').build();
         assertEquals(Character.valueOf('"'), formatWithQuoteChar.getQuoteCharacter());
     }
 
     @Test
     public void testWithQuoteLFThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withQuote(LF));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setQuote(LF));
     }
 
     @Test
     public void testWithQuotePolicy() {
-        final CSVFormat formatWithQuotePolicy = CSVFormat.DEFAULT.withQuoteMode(QuoteMode.ALL);
+        final CSVFormat formatWithQuotePolicy = CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).build();
         assertEquals(QuoteMode.ALL, formatWithQuotePolicy.getQuoteMode());
     }
 
     @Test
     public void testWithRecordSeparatorCR() {
-        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.withRecordSeparator(CR);
+        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.builder().setRecordSeparator(CR).build();
         assertEquals(String.valueOf(CR), formatWithRecordSeparator.getRecordSeparator());
     }
 
     @Test
     public void testWithRecordSeparatorCRLF() {
-        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.withRecordSeparator(CRLF);
+        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.builder().setRecordSeparator(CRLF).build();
         assertEquals(CRLF, formatWithRecordSeparator.getRecordSeparator());
     }
 
     @Test
     public void testWithRecordSeparatorLF() {
-        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.withRecordSeparator(LF);
+        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.builder().setRecordSeparator(LF).build();
         assertEquals(String.valueOf(LF), formatWithRecordSeparator.getRecordSeparator());
     }
 
     @Test
     public void testWithSystemRecordSeparator() {
-        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.withSystemRecordSeparator();
+        final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.builder().setRecordSeparator(System.lineSeparator()).build();
         assertEquals(System.getProperty("line.separator"), formatWithRecordSeparator.getRecordSeparator());
     }
 }

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -252,7 +252,7 @@ public class CSVPrinterTest {
     @Test
     public void testCloseWithCsvFormatAutoFlushOff() throws IOException {
         try (final Writer writer = mock(Writer.class)) {
-            final CSVFormat csvFormat = CSVFormat.DEFAULT.withAutoFlush(false);
+            final CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setAutoFlush(false).build();
             try (CSVPrinter csvPrinter = new CSVPrinter(writer, csvFormat)) {
                 // empty
             }
@@ -265,7 +265,7 @@ public class CSVPrinterTest {
     public void testCloseWithCsvFormatAutoFlushOn() throws IOException {
         // System.out.println("start method");
         try (final Writer writer = mock(Writer.class)) {
-            final CSVFormat csvFormat = CSVFormat.DEFAULT.withAutoFlush(true);
+            final CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setAutoFlush(true).build();
             try (CSVPrinter csvPrinter = new CSVPrinter(writer, csvFormat)) {
                 // empty
             }
@@ -299,7 +299,7 @@ public class CSVPrinterTest {
     public void testCRComment() throws IOException {
         final StringWriter sw = new StringWriter();
         final Object value = "abc";
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withCommentMarker('#'))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setCommentMarker('#').build())) {
             printer.print(value);
             printer.printComment("This is a comment\r\non multiple lines\rthis is next comment\r");
             assertEquals("abc" + recordSeparator + "# This is a comment" + recordSeparator + "# on multiple lines"
@@ -334,7 +334,7 @@ public class CSVPrinterTest {
     public void testCSV259() throws IOException {
         final StringWriter sw = new StringWriter();
         try (final Reader reader = new FileReader("src/test/resources/org/apache/commons/csv/CSV-259/sample.txt");
-                final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape('!').withQuote(null))) {
+                final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setEscape('!').setQuote(null).build())) {
             printer.print(reader);
             assertEquals("x!,y!,z", sw.toString());
         }
@@ -343,7 +343,7 @@ public class CSVPrinterTest {
     @Test
     public void testDelimeterQuoted() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote('\''))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote('\'').build())) {
             printer.print("a,b,c");
             printer.print("xyz");
             assertEquals("'a,b,c',xyz", sw.toString());
@@ -353,7 +353,7 @@ public class CSVPrinterTest {
     @Test
     public void testDelimeterQuoteNone() throws IOException {
         final StringWriter sw = new StringWriter();
-        final CSVFormat format = CSVFormat.DEFAULT.withEscape('!').withQuoteMode(QuoteMode.NONE);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setEscape('!').setQuoteMode(QuoteMode.NONE).build();
         try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
             printer.print("a,b,c");
             printer.print("xyz");
@@ -386,7 +386,7 @@ public class CSVPrinterTest {
     @Test
     public void testDelimiterEscaped() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape('!').withQuote(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setEscape('!').setQuote(null).build())) {
             printer.print("a,b,c");
             printer.print("xyz");
             assertEquals("a!,b!,c,xyz", sw.toString());
@@ -396,7 +396,7 @@ public class CSVPrinterTest {
     @Test
     public void testDelimiterPlain() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(null).build())) {
             printer.print("a,b,c");
             printer.print("xyz");
             assertEquals("a,b,c,xyz", sw.toString());
@@ -434,7 +434,7 @@ public class CSVPrinterTest {
     @Test
     public void testEolEscaped() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null).withEscape('!'))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(null).setEscape('!').build())) {
             printer.print("a\rb\nc");
             printer.print("x\fy\bz");
             assertEquals("a!rb!nc,x\fy\bz", sw.toString());
@@ -444,7 +444,7 @@ public class CSVPrinterTest {
     @Test
     public void testEolPlain() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(null).build())) {
             printer.print("a\rb\nc");
             printer.print("x\fy\bz");
             assertEquals("a\rb\nc,x\fy\bz", sw.toString());
@@ -454,7 +454,7 @@ public class CSVPrinterTest {
     @Test
     public void testEolQuoted() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote('\''))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote('\'').build())) {
             printer.print("a\rb\nc");
             printer.print("x\by\fz");
             assertEquals("'a\rb\nc',x\by\fz", sw.toString());
@@ -464,7 +464,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeBackslash1() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(QUOTE_CH))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(QUOTE_CH).build())) {
             printer.print("\\");
         }
         assertEquals("\\", sw.toString());
@@ -473,7 +473,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeBackslash2() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(QUOTE_CH))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(QUOTE_CH).build())) {
             printer.print("\\\r");
         }
         assertEquals("'\\\r'", sw.toString());
@@ -482,7 +482,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeBackslash3() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(QUOTE_CH))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(QUOTE_CH).build())) {
             printer.print("X\\\r");
         }
         assertEquals("'X\\\r'", sw.toString());
@@ -491,7 +491,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeBackslash4() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(QUOTE_CH))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(QUOTE_CH).build())) {
             printer.print("\\\\");
         }
         assertEquals("\\\\", sw.toString());
@@ -500,7 +500,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeBackslash5() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(QUOTE_CH))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(QUOTE_CH).build())) {
             printer.print("\\\\");
         }
         assertEquals("\\\\", sw.toString());
@@ -509,7 +509,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeNull1() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setEscape(null).build())) {
             printer.print("\\");
         }
         assertEquals("\\", sw.toString());
@@ -518,7 +518,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeNull2() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setEscape(null).build())) {
             printer.print("\\\r");
         }
         assertEquals("\"\\\r\"", sw.toString());
@@ -527,7 +527,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeNull3() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setEscape(null).build())) {
             printer.print("X\\\r");
         }
         assertEquals("\"X\\\r\"", sw.toString());
@@ -536,7 +536,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeNull4() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setEscape(null).build())) {
             printer.print("\\\\");
         }
         assertEquals("\\\\", sw.toString());
@@ -545,7 +545,7 @@ public class CSVPrinterTest {
     @Test
     public void testEscapeNull5() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setEscape(null).build())) {
             printer.print("\\\\");
         }
         assertEquals("\\\\", sw.toString());
@@ -620,7 +620,7 @@ public class CSVPrinterTest {
     public void testHeader() throws IOException {
         final StringWriter sw = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(sw,
-                CSVFormat.DEFAULT.withQuote(null).withHeader("C1", "C2", "C3"))) {
+                CSVFormat.DEFAULT.builder().setQuote(null).setHeader("C1", "C2", "C3").build())) {
             printer.printRecord("a", "b", "c");
             printer.printRecord("x", "y", "z");
             assertEquals("C1,C2,C3\r\na,b,c\r\nx,y,z\r\n", sw.toString());
@@ -652,7 +652,7 @@ public class CSVPrinterTest {
     @Test
     public void testHeaderNotSet() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(null).build())) {
             printer.printRecord("a", "b", "c");
             printer.printRecord("x", "y", "z");
             assertEquals("a,b,c\r\nx,y,z\r\n", sw.toString());
@@ -661,7 +661,7 @@ public class CSVPrinterTest {
 
     @Test
     public void testInvalidFormat() {
-        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.withDelimiter(CR));
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setDelimiter(CR));
     }
 
     @Test
@@ -686,7 +686,7 @@ public class CSVPrinterTest {
             setUpTable(connection);
             try (final Statement stmt = connection.createStatement();
                     final ResultSet resultSet = stmt.executeQuery("select ID, NAME, TEXT from TEST");
-                    final CSVPrinter printer = CSVFormat.DEFAULT.withHeader(resultSet).print(sw)) {
+                    final CSVPrinter printer = CSVFormat.DEFAULT.builder().setHeader(resultSet).build().print(sw)) {
                 printer.printRecords(resultSet);
             }
         }
@@ -723,7 +723,7 @@ public class CSVPrinterTest {
             setUpTable(connection);
             try (final Statement stmt = connection.createStatement();
                     final ResultSet resultSet = stmt.executeQuery("select ID, NAME, TEXT from TEST");
-                    final CSVPrinter printer = CSVFormat.DEFAULT.withHeader(resultSet.getMetaData()).print(sw)) {
+                    final CSVPrinter printer = CSVFormat.DEFAULT.builder().setHeader(resultSet.getMetaData()).build().print(sw)) {
                 printer.printRecords(resultSet);
                 assertEquals("ID,NAME,TEXT" + recordSeparator + "1,r1,\"long text 1\"" + recordSeparator + "2,r2,\""
                         + longText2 + "\"" + recordSeparator, sw.toString());
@@ -734,7 +734,7 @@ public class CSVPrinterTest {
     @Test
     @Disabled
     public void testJira135_part1() throws IOException {
-        final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setRecordSeparator('\n').setQuote(DQUOTE_CHAR).setEscape(BACKSLASH).build();
         final StringWriter sw = new StringWriter();
         final List<String> list = new LinkedList<>();
         try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
@@ -750,7 +750,7 @@ public class CSVPrinterTest {
     @Test
     @Disabled
     public void testJira135_part2() throws IOException {
-        final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setRecordSeparator('\n').setQuote(DQUOTE_CHAR).setEscape(BACKSLASH).build();
         final StringWriter sw = new StringWriter();
         final List<String> list = new LinkedList<>();
         try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
@@ -766,7 +766,7 @@ public class CSVPrinterTest {
     @Test
     @Disabled
     public void testJira135_part3() throws IOException {
-        final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setRecordSeparator('\n').setQuote(DQUOTE_CHAR).setEscape(BACKSLASH).build();
         final StringWriter sw = new StringWriter();
         final List<String> list = new LinkedList<>();
         try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
@@ -782,7 +782,7 @@ public class CSVPrinterTest {
     @Test
     @Disabled
     public void testJira135All() throws IOException {
-        final CSVFormat format = CSVFormat.DEFAULT.withRecordSeparator('\n').withQuote(DQUOTE_CHAR).withEscape(BACKSLASH);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setRecordSeparator('\n').setQuote(DQUOTE_CHAR).setEscape(BACKSLASH).build();
         final StringWriter sw = new StringWriter();
         final List<String> list = new LinkedList<>();
         try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
@@ -863,7 +863,7 @@ public class CSVPrinterTest {
     @Test
     public void testMultiLineComment() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withCommentMarker('#'))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setCommentMarker('#').build())) {
             printer.printComment("This is a comment\non multiple lines");
 
             assertEquals("# This is a comment" + recordSeparator + "# on multiple lines" + recordSeparator,
@@ -874,8 +874,8 @@ public class CSVPrinterTest {
     @Test
     public void testMySqlNullOutput() throws IOException {
         Object[] s = new String[] { "NULL", null };
-        CSVFormat format = CSVFormat.MYSQL.withQuote(DQUOTE_CHAR).withNullString("NULL")
-            .withQuoteMode(QuoteMode.NON_NUMERIC);
+        CSVFormat format = CSVFormat.MYSQL.builder().setQuote(DQUOTE_CHAR).setNullString("NULL")
+            .setQuoteMode(QuoteMode.NON_NUMERIC).build();
         StringWriter writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -886,7 +886,7 @@ public class CSVPrinterTest {
         assertArrayEquals(s, record0);
 
         s = new String[] { "\\N", null };
-        format = CSVFormat.MYSQL.withNullString("\\N");
+        format = CSVFormat.MYSQL.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -897,7 +897,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "\\N", "A" };
-        format = CSVFormat.MYSQL.withNullString("\\N");
+        format = CSVFormat.MYSQL.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -908,7 +908,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "\n", "A" };
-        format = CSVFormat.MYSQL.withNullString("\\N");
+        format = CSVFormat.MYSQL.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -919,7 +919,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "", null };
-        format = CSVFormat.MYSQL.withNullString("NULL");
+        format = CSVFormat.MYSQL.builder().setNullString("NULL").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1002,7 +1002,7 @@ public class CSVPrinterTest {
     @Test
     public void testParseCustomNullValues() throws IOException {
         final StringWriter sw = new StringWriter();
-        final CSVFormat format = CSVFormat.DEFAULT.withNullString("NULL");
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setNullString("NULL").build();
         try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
             printer.printRecord("a", null, "b");
         }
@@ -1021,7 +1021,7 @@ public class CSVPrinterTest {
     @Test
     public void testPlainEscaped() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null).withEscape('!'))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(null).setEscape('!').build())) {
             printer.print("abc");
             printer.print("xyz");
             assertEquals("abc,xyz", sw.toString());
@@ -1031,7 +1031,7 @@ public class CSVPrinterTest {
     @Test
     public void testPlainPlain() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(null).build())) {
             printer.print("abc");
             printer.print("xyz");
             assertEquals("abc,xyz", sw.toString());
@@ -1041,7 +1041,7 @@ public class CSVPrinterTest {
     @Test
     public void testPlainQuoted() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote('\''))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote('\'').build())) {
             printer.print("abc");
             assertEquals("abc", sw.toString());
         }
@@ -1051,7 +1051,7 @@ public class CSVPrinterTest {
     @Disabled
     public void testPostgreSqlCsvNullOutput() throws IOException {
         Object[] s = new String[] { "NULL", null };
-        CSVFormat format = CSVFormat.POSTGRESQL_CSV.withQuote(DQUOTE_CHAR).withNullString("NULL").withQuoteMode(QuoteMode.ALL_NON_NULL);
+        CSVFormat format = CSVFormat.POSTGRESQL_CSV.builder().setQuote(DQUOTE_CHAR).setNullString("NULL").setQuoteMode(QuoteMode.ALL_NON_NULL).build();
         StringWriter writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1062,7 +1062,7 @@ public class CSVPrinterTest {
         assertArrayEquals(new Object[2], record0);
 
         s = new String[] { "\\N", null };
-        format = CSVFormat.POSTGRESQL_CSV.withNullString("\\N");
+        format = CSVFormat.POSTGRESQL_CSV.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1073,7 +1073,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "\\N", "A" };
-        format = CSVFormat.POSTGRESQL_CSV.withNullString("\\N");
+        format = CSVFormat.POSTGRESQL_CSV.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1084,7 +1084,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "\n", "A" };
-        format = CSVFormat.POSTGRESQL_CSV.withNullString("\\N");
+        format = CSVFormat.POSTGRESQL_CSV.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1095,7 +1095,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "", null };
-        format = CSVFormat.POSTGRESQL_CSV.withNullString("NULL");
+        format = CSVFormat.POSTGRESQL_CSV.builder().setNullString("NULL").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1154,7 +1154,7 @@ public class CSVPrinterTest {
     @Disabled
     public void testPostgreSqlCsvTextOutput() throws IOException {
         Object[] s = new String[] { "NULL", null };
-        CSVFormat format = CSVFormat.POSTGRESQL_TEXT.withQuote(DQUOTE_CHAR).withNullString("NULL").withQuoteMode(QuoteMode.ALL_NON_NULL);
+        CSVFormat format = CSVFormat.POSTGRESQL_TEXT.builder().setQuote(DQUOTE_CHAR).setNullString("NULL").setQuoteMode(QuoteMode.ALL_NON_NULL).build();
         StringWriter writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1165,7 +1165,7 @@ public class CSVPrinterTest {
         assertArrayEquals(new Object[2], record0);
 
         s = new String[] { "\\N", null };
-        format = CSVFormat.POSTGRESQL_TEXT.withNullString("\\N");
+        format = CSVFormat.POSTGRESQL_TEXT.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1176,7 +1176,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "\\N", "A" };
-        format = CSVFormat.POSTGRESQL_TEXT.withNullString("\\N");
+        format = CSVFormat.POSTGRESQL_TEXT.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1187,7 +1187,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "\n", "A" };
-        format = CSVFormat.POSTGRESQL_TEXT.withNullString("\\N");
+        format = CSVFormat.POSTGRESQL_TEXT.builder().setNullString("\\N").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1198,7 +1198,7 @@ public class CSVPrinterTest {
         assertArrayEquals(expectNulls(s, format), record0);
 
         s = new String[] { "", null };
-        format = CSVFormat.POSTGRESQL_TEXT.withNullString("NULL");
+        format = CSVFormat.POSTGRESQL_TEXT.builder().setNullString("NULL").build();
         writer = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(writer, format)) {
             printer.printRecord(s);
@@ -1337,7 +1337,7 @@ public class CSVPrinterTest {
     @Test
     public void testPrintCustomNullValues() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withNullString("NULL"))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setNullString("NULL").build())) {
             printer.printRecord("a", null, "b");
             assertEquals("a,NULL,b" + recordSeparator, sw.toString());
         }
@@ -1418,7 +1418,7 @@ public class CSVPrinterTest {
     @Test
     public void testPrintOnePositiveInteger() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuoteMode(QuoteMode.MINIMAL))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.MINIMAL).build())) {
             printer.print(Integer.MAX_VALUE);
             assertEquals(String.valueOf(Integer.MAX_VALUE), sw.toString());
         }
@@ -1438,7 +1438,7 @@ public class CSVPrinterTest {
     public void testPrintReaderWithoutQuoteToAppendable() throws IOException {
         final StringBuilder sb = new StringBuilder();
         final String content = "testValue";
-        try (final CSVPrinter printer = new CSVPrinter(sb, CSVFormat.DEFAULT.withQuote(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sb, CSVFormat.DEFAULT.builder().setQuote(null).build())) {
             final StringReader value = new StringReader(content);
             printer.print(value);
         }
@@ -1459,7 +1459,7 @@ public class CSVPrinterTest {
     public void testPrintReaderWithoutQuoteToWriter() throws IOException {
         final StringWriter sw = new StringWriter();
         final String content = "testValue";
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote(null))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote(null).build())) {
             final StringReader value = new StringReader(content);
             printer.print(value);
         }
@@ -1573,7 +1573,7 @@ public class CSVPrinterTest {
     @Test
     public void testQuoteAll() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuoteMode(QuoteMode.ALL))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).build())) {
             printer.printRecord("a", "b\nc", "d");
             assertEquals("\"a\",\"b\nc\",\"d\"" + recordSeparator, sw.toString());
         }
@@ -1591,7 +1591,7 @@ public class CSVPrinterTest {
     @Test
     public void testQuoteNonNumeric() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuoteMode(QuoteMode.NON_NUMERIC))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.NON_NUMERIC).build())) {
             printer.printRecord("a", "b\nc", Integer.valueOf(1));
             assertEquals("\"a\",\"b\nc\",1" + recordSeparator, sw.toString());
         }
@@ -1650,7 +1650,7 @@ public class CSVPrinterTest {
     @Test
     public void testSingleLineComment() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withCommentMarker('#'))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setCommentMarker('#').build())) {
             printer.printComment("This is a comment");
             assertEquals("# This is a comment" + recordSeparator, sw.toString());
         }
@@ -1659,7 +1659,7 @@ public class CSVPrinterTest {
     @Test
     public void testSingleQuoteQuoted() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuote('\''))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setQuote('\'').build())) {
             printer.print("a'b'c");
             printer.print("xyz");
             assertEquals("'a''b''c',xyz", sw.toString());
@@ -1671,7 +1671,7 @@ public class CSVPrinterTest {
         // functionally identical to testHeader, used to test CSV-153
         final StringWriter sw = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(sw,
-                CSVFormat.DEFAULT.withQuote(null).withHeader("C1", "C2", "C3").withSkipHeaderRecord(false))) {
+                CSVFormat.DEFAULT.builder().setQuote(null).setHeader("C1", "C2", "C3").setSkipHeaderRecord(false).build())) {
             printer.printRecord("a", "b", "c");
             printer.printRecord("x", "y", "z");
             assertEquals("C1,C2,C3\r\na,b,c\r\nx,y,z\r\n", sw.toString());
@@ -1683,7 +1683,7 @@ public class CSVPrinterTest {
         // functionally identical to testHeaderNotSet, used to test CSV-153
         final StringWriter sw = new StringWriter();
         try (final CSVPrinter printer = new CSVPrinter(sw,
-                CSVFormat.DEFAULT.withQuote(null).withHeader("C1", "C2", "C3").withSkipHeaderRecord(true))) {
+                CSVFormat.DEFAULT.builder().setQuote(null).setHeader("C1", "C2", "C3").setSkipHeaderRecord(true).build())) {
             printer.printRecord("a", "b", "c");
             printer.printRecord("x", "y", "z");
             assertEquals("a,b,c\r\nx,y,z\r\n", sw.toString());
@@ -1693,7 +1693,7 @@ public class CSVPrinterTest {
     @Test
     public void testTrailingDelimiterOnTwoColumns() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withTrailingDelimiter())) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setTrailingDelimiter(true).build())) {
             printer.printRecord("A", "B");
             assertEquals("A,B,\r\n", sw.toString());
         }
@@ -1702,7 +1702,7 @@ public class CSVPrinterTest {
     @Test
     public void testTrimOffOneColumn() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withTrim(false))) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setTrim(false).build())) {
             printer.print(" A ");
             assertEquals("\" A \"", sw.toString());
         }
@@ -1711,7 +1711,7 @@ public class CSVPrinterTest {
     @Test
     public void testTrimOnOneColumn() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withTrim())) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setTrim(true).build())) {
             printer.print(" A ");
             assertEquals("A", sw.toString());
         }
@@ -1720,7 +1720,7 @@ public class CSVPrinterTest {
     @Test
     public void testTrimOnTwoColumns() throws IOException {
         final StringWriter sw = new StringWriter();
-        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withTrim())) {
+        try (final CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setTrim(true).build())) {
             printer.print(" A ");
             printer.print(" B ");
             assertEquals("A,B", sw.toString());
@@ -1732,7 +1732,7 @@ public class CSVPrinterTest {
     }
 
     private void tryFormat(final List<String> list, final Character quote, final Character escape, final String expected) throws IOException {
-        final CSVFormat format = CSVFormat.DEFAULT.withQuote(quote).withEscape(escape).withRecordSeparator(null);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setQuote(quote).setEscape(escape).setRecordSeparator(null).build();
         final Appendable out = new StringBuilder();
         try (final CSVPrinter printer = new CSVPrinter(out, format)) {
             printer.printRecord(list);

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -82,7 +82,7 @@ public class CSVRecordTest {
 
     @Test
     public void testCSVRecordNULLValues() throws IOException {
-        final CSVParser parser = CSVParser.parse("A,B\r\nONE,TWO", CSVFormat.DEFAULT.withHeader());
+        final CSVParser parser = CSVParser.parse("A,B\r\nONE,TWO", CSVFormat.DEFAULT.builder().setHeader().build());
         final CSVRecord csvRecord = new CSVRecord(parser, null, null, 0L, 0L);
         assertEquals(0, csvRecord.size());
         assertThrows(IllegalArgumentException.class, () -> csvRecord.get("B"));
@@ -159,7 +159,7 @@ public class CSVRecordTest {
     public void testIsInconsistent() throws IOException {
         final String[] headers = { "first", "second", "third" };
         final String rowData = StringUtils.join(values, ',');
-        try (final CSVParser parser = CSVFormat.DEFAULT.withHeader(headers).parse(new StringReader(rowData))) {
+        try (final CSVParser parser = CSVFormat.DEFAULT.builder().setHeader(headers).build().parse(new StringReader(rowData))) {
             final Map<String, Integer> map = parser.getHeaderMapRaw();
             final CSVRecord record1 = parser.iterator().next();
             map.put("fourth", Integer.valueOf(4));
@@ -228,7 +228,8 @@ public class CSVRecordTest {
     @Test
     public void testSerialization() throws IOException, ClassNotFoundException {
         final CSVRecord shortRec;
-        try (final CSVParser parser = CSVParser.parse("A,B\n#my comment\nOne,Two", CSVFormat.DEFAULT.withHeader().withCommentMarker('#'))) {
+        try (final CSVParser parser = CSVParser.parse("A,B\n#my comment\nOne,Two",
+                CSVFormat.DEFAULT.builder().setHeader().setCommentMarker('#').build())) {
             shortRec = parser.iterator().next();
         }
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -327,7 +328,7 @@ public class CSVRecordTest {
 
     @Test
     public void testToMapWithShortRecord() throws Exception {
-        try (final CSVParser parser = CSVParser.parse("a,b", CSVFormat.DEFAULT.withHeader("A", "B", "C"))) {
+        try (final CSVParser parser = CSVParser.parse("a,b", CSVFormat.DEFAULT.builder().setHeader("A", "B", "C").build())) {
             final CSVRecord shortRec = parser.iterator().next();
             shortRec.toMap();
         }

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -54,7 +54,7 @@ public class LexerTest {
 
     @BeforeEach
     public void setUp() {
-        formatWithEscaping = CSVFormat.DEFAULT.withEscape('\\');
+        formatWithEscaping = CSVFormat.DEFAULT.builder().setEscape('\\').build();
     }
 
     // simple token with escaping enabled
@@ -64,7 +64,7 @@ public class LexerTest {
          * file: a,\,,b \,,
          */
         final String code = "a,\\,,b\\\\\n\\,,\\\nc,d\\\r\ne";
-        final CSVFormat format = formatWithEscaping.withIgnoreEmptyLines(false);
+        final CSVFormat format = formatWithEscaping.builder().setIgnoreEmptyLines(false).build();
         assertTrue(format.isEscapeCharacterSet());
         try (final Lexer parser = createLexer(code, format)) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "a"));
@@ -110,7 +110,7 @@ public class LexerTest {
     public void testComments() throws IOException {
         final String code = "first,line,\n" + "second,line,tokenWith#no-comment\n" + "# comment line \n" +
                 "third,line,#no-comment\n" + "# penultimate comment\n" + "# Final comment\n";
-        final CSVFormat format = CSVFormat.DEFAULT.withCommentMarker('#');
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setCommentMarker('#').build();
         try (final Lexer parser = createLexer(code, format)) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "first"));
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "line"));
@@ -145,7 +145,7 @@ public class LexerTest {
                 "\n" + // 6b
                 "\n" + // 6c
                 "# Final comment\n"; // 7
-        final CSVFormat format = CSVFormat.DEFAULT.withCommentMarker('#').withIgnoreEmptyLines(false);
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setCommentMarker('#').setIgnoreEmptyLines(false).build();
         assertFalse(format.getIgnoreEmptyLines(), "Should not ignore empty lines");
 
         try (final Lexer parser = createLexer(code, format)) {
@@ -214,14 +214,14 @@ public class LexerTest {
     @Test
     public void testEscapedControlCharacter() throws Exception {
         // we are explicitly using an escape different from \ here
-        try (final Lexer lexer = createLexer("character!rEscaped", CSVFormat.DEFAULT.withEscape('!'))) {
+        try (final Lexer lexer = createLexer("character!rEscaped", CSVFormat.DEFAULT.builder().setEscape('!').build())) {
             assertThat(lexer.nextToken(new Token()), hasContent("character" + CR + "Escaped"));
         }
     }
 
     @Test
     public void testEscapedControlCharacter2() throws Exception {
-        try (final Lexer lexer = createLexer("character\\rEscaped", CSVFormat.DEFAULT.withEscape('\\'))) {
+        try (final Lexer lexer = createLexer("character\\rEscaped", CSVFormat.DEFAULT.builder().setEscape('\\').build())) {
             assertThat(lexer.nextToken(new Token()), hasContent("character" + CR + "Escaped"));
         }
     }
@@ -282,7 +282,7 @@ public class LexerTest {
     public void testIgnoreEmptyLines() throws IOException {
         final String code = "first,line,\n" + "\n" + "\n" + "second,line\n" + "\n" + "\n" + "third line \n" + "\n" +
                 "\n" + "last, line \n" + "\n" + "\n" + "\n";
-        final CSVFormat format = CSVFormat.DEFAULT.withIgnoreEmptyLines();
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setIgnoreEmptyLines(true).build();
         try (final Lexer parser = createLexer(code, format)) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "first"));
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "line"));
@@ -299,7 +299,7 @@ public class LexerTest {
 
     @Test
     public void testIsMetaCharCommentStart() throws IOException {
-        try (final Lexer lexer = createLexer("#", CSVFormat.DEFAULT.withCommentMarker('#'))) {
+        try (final Lexer lexer = createLexer("#", CSVFormat.DEFAULT.builder().setCommentMarker('#').build())) {
             final int ch = lexer.readEscape();
             assertEquals('#', ch);
         }
@@ -320,7 +320,7 @@ public class LexerTest {
          * file: a,"foo",b a, " foo",b a,"foo " ,b // whitespace after closing encapsulator a, " foo " ,b
          */
         final String code = "a,\"foo\",b\na,   \" foo\",b\na,\"foo \"  ,b\na,  \" foo \"  ,b";
-        try (final Lexer parser = createLexer(code, CSVFormat.DEFAULT.withIgnoreSurroundingSpaces())) {
+        try (final Lexer parser = createLexer(code, CSVFormat.DEFAULT.builder().setIgnoreSurroundingSpaces(true).build())) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "a"));
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "foo"));
             assertThat(parser.nextToken(new Token()), matches(EORECORD, "b"));
@@ -357,7 +357,7 @@ public class LexerTest {
          * file: a;'b and \' more ' !comment;;;; ;;
          */
         final String code = "a;'b and '' more\n'\n!comment;;;;\n;;";
-        final CSVFormat format = CSVFormat.DEFAULT.withQuote('\'').withCommentMarker('!').withDelimiter(';');
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setQuote('\'').setCommentMarker('!').setDelimiter(';').build();
         try (final Lexer parser = createLexer(code, format)) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "a"));
             assertThat(parser.nextToken(new Token()), matches(EORECORD, "b and ' more\n"));
@@ -366,7 +366,7 @@ public class LexerTest {
 
     @Test
     public void testReadEscapeBackspace() throws IOException {
-        try (final Lexer lexer = createLexer("b", CSVFormat.DEFAULT.withEscape('\b'))) {
+        try (final Lexer lexer = createLexer("b", CSVFormat.DEFAULT.builder().setEscape('\b').build())) {
             final int ch = lexer.readEscape();
             assertEquals(BACKSPACE, ch);
         }
@@ -374,7 +374,7 @@ public class LexerTest {
 
     @Test
     public void testReadEscapeFF() throws IOException {
-        try (final Lexer lexer = createLexer("f", CSVFormat.DEFAULT.withEscape('\f'))) {
+        try (final Lexer lexer = createLexer("f", CSVFormat.DEFAULT.builder().setEscape('\f').build())) {
             final int ch = lexer.readEscape();
             assertEquals(FF, ch);
         }
@@ -382,7 +382,7 @@ public class LexerTest {
 
     @Test
     public void testReadEscapeTab() throws IOException {
-        try (final Lexer lexer = createLexer("t", CSVFormat.DEFAULT.withEscape('\t'))) {
+        try (final Lexer lexer = createLexer("t", CSVFormat.DEFAULT.builder().setEscape('\t').build())) {
             final int ch = lexer.readEscape();
             assertThat(lexer.nextToken(new Token()), matches(EOF, ""));
             assertEquals(TAB, ch);
@@ -392,7 +392,7 @@ public class LexerTest {
     @Test
     public void testSurroundingSpacesAreDeleted() throws IOException {
         final String code = "noSpaces,  leadingSpaces,trailingSpaces  ,  surroundingSpaces  ,  ,,";
-        try (final Lexer parser = createLexer(code, CSVFormat.DEFAULT.withIgnoreSurroundingSpaces())) {
+        try (final Lexer parser = createLexer(code, CSVFormat.DEFAULT.builder().setIgnoreSurroundingSpaces(true).build())) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "noSpaces"));
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "leadingSpaces"));
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "trailingSpaces"));
@@ -406,7 +406,7 @@ public class LexerTest {
     @Test
     public void testSurroundingTabsAreDeleted() throws IOException {
         final String code = "noTabs,\tleadingTab,trailingTab\t,\tsurroundingTabs\t,\t\t,,";
-        try (final Lexer parser = createLexer(code, CSVFormat.DEFAULT.withIgnoreSurroundingSpaces())) {
+        try (final Lexer parser = createLexer(code, CSVFormat.DEFAULT.builder().setIgnoreSurroundingSpaces(true).build())) {
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "noTabs"));
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "leadingTab"));
             assertThat(parser.nextToken(new Token()), matches(TOKEN, "trailingTab"));

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv149Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv149Test.java
@@ -50,7 +50,7 @@ public class JiraCsv149Test {
         // @formatter:on
         int lineCounter = 2;
         try (final CSVParser parser = new CSVParser(records, format)) {
-            for (final CSVRecord record : parser) {
+            for (@SuppressWarnings("unused") final CSVRecord record : parser) {
                 assertEquals(lineCounter++, parser.getCurrentLineNumber());
             }
         }

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv211Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv211Test.java
@@ -38,7 +38,7 @@ public class JiraCsv211Test {
             .setHeader("ID", "Name", "Country", "Age")
             .build();
         // @formatter:on
-        final String formatted = printFormat.format(values);
+        final String formatted = printFormat.format((Object[]) values);
         assertEquals("ID\tName\tCountry\tAge\r\n1\tJane Doe\tUSA\t", formatted);
 
         final CSVFormat parseFormat = CSVFormat.DEFAULT.builder().setDelimiter('\t').setHeader()


### PR DESCRIPTION
This PR updates unit tests to use the library's new API and thus remove all warnings (mostly deprecation) in tests.