### PR TITLE
[CSV-303] Add revapi to fail build on breaking API changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,8 +316,34 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <consoleOutput>true</consoleOutput>
+          <excludes>
+            <exclude>**/revapi*.json</exclude>
+          </excludes>
+        </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <version>0.14.7</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-java</artifactId>
+            <version>0.27.0</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <failSeverity>breaking</failSeverity>
+          <checkDependencies>false</checkDependencies>
+          <failOnMissingConfigurationFiles>true</failOnMissingConfigurationFiles>
+          <analysisConfigurationFiles>
+            <path>src/test/resources/revapi-config.json</path>
+          </analysisConfigurationFiles>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/test/resources/revapi-config.json
+++ b/src/test/resources/revapi-config.json
@@ -1,0 +1,18 @@
+[
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.field.serialVersionUIDUnchanged",
+          "old": "field org.apache.commons.csv.CSVFormat.serialVersionUID",
+          "new": "field org.apache.commons.csv.CSVFormat.serialVersionUID",
+          "serialVersionUID": "1",
+          "justification": "CSV-302 - Ignore for the time being to not break the build"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
This pull request solves ticket [CSV-303](https://issues.apache.org/jira/browse/CSV-303) by adding `org.revapi:revapi-maven-plugin` to the build section of the library's maven POM.
Please note that config file `revapi-config.json` is added to exclude `CSVFormat.serialVersionUID` from checks. The field should probably be updated to something != 1 along with custom de-serialization for backward compatibility (see ticket [CSV-302](https://issues.apache.org/jira/browse/CSV-302)).