### PR TITLE
[CSV-304] Accessors for header/trailer comments

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -352,6 +352,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
 
         return new CSVParser(new InputStreamReader(url.openStream(), charset), format);
     }
+
     private String headerComment;
 
     private String trailerComment;
@@ -487,8 +488,10 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
                 }
             } else {
                 if (this.format.getSkipHeaderRecord()) {
-                    final CSVRecord csvRecord = this.nextRecord();
-                    headerComment = csvRecord.getComment();
+                    final CSVRecord nextRecord = this.nextRecord();
+                    if (nextRecord != null) {
+                        headerComment = nextRecord.getComment();
+                    }
                 }
                 headerRecord = formatHeader;
             }
@@ -764,10 +767,8 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
             case EOF:
                 if (this.reusableToken.isReady) {
                     this.addRecordValue(true);
-                } else {
-                    if (sb != null) {
+                } else if (sb != null) {
                         trailerComment = sb.toString();
-                    }
                 }
                 break;
             case INVALID:

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -604,6 +604,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     public List<String> getHeaderNames() {
         return Collections.unmodifiableList(headers.headerNames);
     }
+
     /**
      * Checks whether there is a header comment.
      * The header comment appears before the header record.
@@ -619,6 +620,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     public boolean hasHeaderComment() {
         return headerComment != null;
     }
+
     /**
      * Returns the header comment, if any.
      * The header comment appears before the header record.
@@ -629,6 +631,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     public String getHeaderComment() {
         return headerComment;
     }
+
     /**
      * Checks whether there is a trailer comment.
      * Trailer comments are located between the last record and EOF.
@@ -641,6 +644,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     public boolean hasTrailerComment() {
         return trailerComment != null;
     }
+
     /**
      * Returns the trailer comment, if any.
      * Trailer comments are located between the last record and EOF
@@ -651,6 +655,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
     public String getTrailerComment() {
         return trailerComment;
     }
+
     /**
      * Returns the current record number in the input stream.
      *

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -602,7 +602,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         return Collections.unmodifiableList(headers.headerNames);
     }
     /**
-     * Checks whether this parser has a header comment, false otherwise.
+     * Checks whether there is a header comment.
      * The header comment appears before the header record.
      * Note that if the parser's format has been given an explicit header
      * (with {@link CSVFormat.Builder#setHeader(String... )} or another overload)
@@ -611,35 +611,39 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
      * will be associated with the first record, not the header.
      *
      * @return true if this parser has seen a header comment, false otherwise
+     * @since 1.10.0
      */
     public boolean hasHeaderComment() {
         return headerComment != null;
     }
     /**
-     * Returns the header comment for this parser, if any.
+     * Returns the header comment, if any.
      * The header comment appears before the header record.
      *
      * @return the header comment for this stream, or null if no comment is available.
+     * @since 1.10.0
      */
     public String getHeaderComment() {
         return headerComment;
     }
     /**
-     * Checks whether this parser has seen a trailer comment, false otherwise.
+     * Checks whether there is a trailer comment.
      * Trailer comments are located between the last record and EOF.
      * The trailer comments will only be available after the parser has
      * finished processing this stream.
      *
      * @return true if this parser has seen a trailer comment, false otherwise
+     * @since 1.10.0
      */
     public boolean hasTrailerComment() {
         return trailerComment != null;
     }
     /**
-     * Returns the trailer comment for this record, if any.
+     * Returns the trailer comment, if any.
      * Trailer comments are located between the last record and EOF
      *
      * @return the trailer comment for this stream, or null if no comment is available.
+     * @since 1.10.0
      */
     public String getTrailerComment() {
         return trailerComment;

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -773,7 +773,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
                 if (this.reusableToken.isReady) {
                     this.addRecordValue(true);
                 } else if (sb != null) {
-                        trailerComment = sb.toString();
+                    trailerComment = sb.toString();
                 }
                 break;
             case INVALID:

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1396,6 +1396,7 @@ public class CSVParserTest {
             .setCommentMarker('#')
             .setHeader("A", "B")
             .build();
+
     @Test
     public void testGetHeaderComment_NoComment1() throws IOException {
 
@@ -1406,6 +1407,7 @@ public class CSVParserTest {
             assertNull(parser.getHeaderComment());
         }
     }
+
     @Test
     public void testGetHeaderComment_HeaderComment1() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_AUTO_HEADER)) {
@@ -1415,6 +1417,7 @@ public class CSVParserTest {
             assertEquals("header comment", parser.getHeaderComment());
         }
     }
+
     @Test
     public void testGetHeaderComment_HeaderTrailerComment() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_MULTILINE_HEADER_TRAILER_COMMENT, FORMAT_AUTO_HEADER)) {
@@ -1424,6 +1427,7 @@ public class CSVParserTest {
             assertEquals("multi-line"+LF+"header comment", parser.getHeaderComment());
         }
     }
+
     @Test
     public void testGetHeaderComment_NoComment2() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_NO_COMMENT, FORMAT_EXPLICIT_HEADER)) {
@@ -1433,6 +1437,7 @@ public class CSVParserTest {
             assertNull(parser.getHeaderComment());
         }
     }
+
     @Test
     public void testGetHeaderComment_HeaderComment2() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER)) {
@@ -1442,6 +1447,7 @@ public class CSVParserTest {
             assertEquals("header comment", parser.getHeaderComment());
         }
     }
+
     @Test
     public void testGetHeaderComment_NoComment3() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_NO_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {
@@ -1451,6 +1457,7 @@ public class CSVParserTest {
             assertNull(parser.getHeaderComment());
         }
     }
+
     @Test
     public void testGetHeaderComment_HeaderComment3() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {
@@ -1469,6 +1476,7 @@ public class CSVParserTest {
             assertNull(parser.getTrailerComment());
         }
     }
+
     @Test
     public void testGetTrailerComment_HeaderTrailerComment1() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_TRAILER_COMMENT, FORMAT_AUTO_HEADER)) {
@@ -1477,6 +1485,7 @@ public class CSVParserTest {
             assertEquals("comment", parser.getTrailerComment());
         }
     }
+
     @Test
     public void testGetTrailerComment_MultilineComment() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_MULTILINE_HEADER_TRAILER_COMMENT, FORMAT_AUTO_HEADER)) {
@@ -1485,6 +1494,7 @@ public class CSVParserTest {
             assertEquals("multi-line"+LF+"comment", parser.getTrailerComment());
         }
     }
+
     @Test
     public void testGetTrailerComment_HeaderComment2() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER)) {
@@ -1493,6 +1503,7 @@ public class CSVParserTest {
             assertNull(parser.getTrailerComment());
         }
     }
+
     @Test
     public void testGetTrailerComment_HeaderTrailerComment2() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_TRAILER_COMMENT, FORMAT_EXPLICIT_HEADER)) {
@@ -1501,6 +1512,7 @@ public class CSVParserTest {
             assertEquals("comment", parser.getTrailerComment());
         }
     }
+
     @Test
     public void testGetTrailerComment_HeaderComment3() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {
@@ -1509,6 +1521,7 @@ public class CSVParserTest {
             assertNull(parser.getTrailerComment());
         }
     }
+
     @Test
     public void testGetTrailerComment_HeaderTrailerComment3() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_TRAILER_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1375,4 +1375,128 @@ public class CSVParserTest {
 
         parser.close();
     }
+    @Test
+    public void getHeaderComment() throws IOException {
+        // File with no header comments
+        String text_1 = "A,B"+CRLF+"1,2"+CRLF;
+        // File with a single line header comment
+        String text_2 = "# comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF;
+        // File with a multi-line header comment
+        String text_3 = "# multi-line" + CRLF + "# comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF;
+        // Format with auto-detected header
+        CSVFormat format_a = CSVFormat.Builder.create(CSVFormat.DEFAULT).setCommentMarker('#').setHeader().build();
+        // Format with explicit header
+        CSVFormat format_b = CSVFormat.Builder.create(CSVFormat.DEFAULT)
+                .setSkipHeaderRecord(true)
+                .setCommentMarker('#')
+                .setHeader("A","B")
+                .build();
+        // Format with explicit header that does not skip the header line
+        CSVFormat format_c = CSVFormat.Builder.create(CSVFormat.DEFAULT)
+                .setCommentMarker('#')
+                .setHeader("A","B")
+                .build();
+
+        try (CSVParser parser = CSVParser.parse(text_1, format_a)) {
+            parser.getRecords();
+            // Expect no header comment
+            assertFalse(parser.hasHeaderComment());
+            assertNull(parser.getHeaderComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_2, format_a)) {
+            parser.getRecords();
+            // Expect a header comment
+            assertTrue(parser.hasHeaderComment());
+            assertEquals("comment", parser.getHeaderComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_3, format_a)) {
+            parser.getRecords();
+            // Expect a header comment
+            assertTrue(parser.hasHeaderComment());
+            assertEquals("multi-line"+LF+"comment", parser.getHeaderComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_1, format_b)) {
+            parser.getRecords();
+            // Expect no header comment
+            assertFalse(parser.hasHeaderComment());
+            assertNull(parser.getHeaderComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_2, format_b)) {
+            parser.getRecords();
+            // Expect a header comment
+            assertTrue(parser.hasHeaderComment());
+            assertEquals("comment", parser.getHeaderComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_1, format_c)) {
+            parser.getRecords();
+            // Expect no header comment
+            assertFalse(parser.hasHeaderComment());
+            assertNull(parser.getHeaderComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_2, format_c)) {
+            parser.getRecords();
+            // Expect no header comment - the text "comment" is attached to the first record
+            assertFalse(parser.hasHeaderComment());
+            assertNull(parser.getHeaderComment());
+        }
+    }
+    @Test
+    public void getTrailerComment() throws IOException {
+        // File with a header comment
+        String text_1 = "# header comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF;
+        // File with a single line header and trailer comment
+        String text_2 = "# header comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF + "# comment";
+        // File with a multi-line header and trailer comment
+        String text_3 = "# multi-line" + CRLF + "# header comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF+"# multi-line"+CRLF+"# comment";
+        // Format with auto-detected header
+        CSVFormat format_a = CSVFormat.Builder.create(CSVFormat.DEFAULT).setCommentMarker('#').setHeader().build();
+        // Format with explicit header
+        CSVFormat format_b = CSVFormat.Builder.create(CSVFormat.DEFAULT)
+                .setSkipHeaderRecord(true)
+                .setCommentMarker('#')
+                .setHeader("A","B")
+                .build();
+        // Format with explicit header that does not skip the header line
+        CSVFormat format_c = CSVFormat.Builder.create(CSVFormat.DEFAULT)
+                .setCommentMarker('#')
+                .setHeader("A","B")
+                .build();
+
+        try (CSVParser parser = CSVParser.parse(text_1, format_a)) {
+            parser.getRecords();
+            assertFalse(parser.hasTrailerComment());
+            assertNull(parser.getTrailerComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_2, format_a)) {
+            parser.getRecords();
+            assertTrue(parser.hasTrailerComment());
+            assertEquals("comment", parser.getTrailerComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_3, format_a)) {
+            parser.getRecords();
+            assertTrue(parser.hasTrailerComment());
+            assertEquals("multi-line"+LF+"comment", parser.getTrailerComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_1, format_b)) {
+            parser.getRecords();
+            assertFalse(parser.hasTrailerComment());
+            assertNull(parser.getTrailerComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_2, format_b)) {
+            parser.getRecords();
+            assertTrue(parser.hasTrailerComment());
+            assertEquals("comment", parser.getTrailerComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_1, format_c)) {
+            parser.getRecords();
+            assertFalse(parser.hasTrailerComment());
+            assertNull(parser.getTrailerComment());
+        }
+        try (CSVParser parser = CSVParser.parse(text_2, format_c)) {
+            parser.getRecords();
+            assertTrue(parser.hasTrailerComment());
+            assertEquals("comment", parser.getTrailerComment());
+        }
+    }
+
 }

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1375,124 +1375,143 @@ public class CSVParserTest {
 
         parser.close();
     }
+    // CSV with no header comments
+    static private final String CSV_INPUT_NO_COMMENT = "A,B"+CRLF+"1,2"+CRLF;
+    // CSV with a header comment
+    static private final String CSV_INPUT_HEADER_COMMENT = "# header comment" + CRLF + "A,B" + CRLF + "1,2" + CRLF;
+    // CSV with a single line header and trailer comment
+    static private final String CSV_INPUT_HEADER_TRAILER_COMMENT = "# header comment" + CRLF + "A,B" + CRLF + "1,2" + CRLF + "# comment";
+    // CSV with a multi-line header and trailer comment
+    static private final String CSV_INPUT_MULTILINE_HEADER_TRAILER_COMMENT = "# multi-line" + CRLF + "# header comment" + CRLF + "A,B" + CRLF + "1,2" + CRLF + "# multi-line" + CRLF + "# comment";
+    // Format with auto-detected header
+    static private final CSVFormat FORMAT_AUTO_HEADER = CSVFormat.Builder.create(CSVFormat.DEFAULT).setCommentMarker('#').setHeader().build();
+    // Format with explicit header
+    static private final CSVFormat FORMAT_EXPLICIT_HEADER = CSVFormat.Builder.create(CSVFormat.DEFAULT)
+            .setSkipHeaderRecord(true)
+            .setCommentMarker('#')
+            .setHeader("A", "B")
+            .build();
+    // Format with explicit header that does not skip the header line
+    CSVFormat FORMAT_EXPLICIT_HEADER_NOSKIP = CSVFormat.Builder.create(CSVFormat.DEFAULT)
+            .setCommentMarker('#')
+            .setHeader("A", "B")
+            .build();
     @Test
-    public void getHeaderComment() throws IOException {
-        // File with no header comments
-        String text_1 = "A,B"+CRLF+"1,2"+CRLF;
-        // File with a single line header comment
-        String text_2 = "# comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF;
-        // File with a multi-line header comment
-        String text_3 = "# multi-line" + CRLF + "# comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF;
-        // Format with auto-detected header
-        CSVFormat format_a = CSVFormat.Builder.create(CSVFormat.DEFAULT).setCommentMarker('#').setHeader().build();
-        // Format with explicit header
-        CSVFormat format_b = CSVFormat.Builder.create(CSVFormat.DEFAULT)
-                .setSkipHeaderRecord(true)
-                .setCommentMarker('#')
-                .setHeader("A","B")
-                .build();
-        // Format with explicit header that does not skip the header line
-        CSVFormat format_c = CSVFormat.Builder.create(CSVFormat.DEFAULT)
-                .setCommentMarker('#')
-                .setHeader("A","B")
-                .build();
+    public void testGetHeaderComment_NoComment1() throws IOException {
 
-        try (CSVParser parser = CSVParser.parse(text_1, format_a)) {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_NO_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();
             // Expect no header comment
             assertFalse(parser.hasHeaderComment());
             assertNull(parser.getHeaderComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_2, format_a)) {
+    }
+    @Test
+    public void testGetHeaderComment_HeaderComment1() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();
             // Expect a header comment
             assertTrue(parser.hasHeaderComment());
-            assertEquals("comment", parser.getHeaderComment());
+            assertEquals("header comment", parser.getHeaderComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_3, format_a)) {
+    }
+    @Test
+    public void testGetHeaderComment_HeaderTrailerComment() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_MULTILINE_HEADER_TRAILER_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();
             // Expect a header comment
             assertTrue(parser.hasHeaderComment());
-            assertEquals("multi-line"+LF+"comment", parser.getHeaderComment());
+            assertEquals("multi-line"+LF+"header comment", parser.getHeaderComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_1, format_b)) {
+    }
+    @Test
+    public void testGetHeaderComment_NoComment2() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_NO_COMMENT, FORMAT_EXPLICIT_HEADER)) {
             parser.getRecords();
             // Expect no header comment
             assertFalse(parser.hasHeaderComment());
             assertNull(parser.getHeaderComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_2, format_b)) {
+    }
+    @Test
+    public void testGetHeaderComment_HeaderComment2() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER)) {
             parser.getRecords();
             // Expect a header comment
             assertTrue(parser.hasHeaderComment());
-            assertEquals("comment", parser.getHeaderComment());
+            assertEquals("header comment", parser.getHeaderComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_1, format_c)) {
+    }
+    @Test
+    public void testGetHeaderComment_NoComment3() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_NO_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {
             parser.getRecords();
             // Expect no header comment
             assertFalse(parser.hasHeaderComment());
             assertNull(parser.getHeaderComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_2, format_c)) {
+    }
+    @Test
+    public void testGetHeaderComment_HeaderComment3() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {
             parser.getRecords();
             // Expect no header comment - the text "comment" is attached to the first record
             assertFalse(parser.hasHeaderComment());
             assertNull(parser.getHeaderComment());
         }
     }
-    @Test
-    public void getTrailerComment() throws IOException {
-        // File with a header comment
-        String text_1 = "# header comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF;
-        // File with a single line header and trailer comment
-        String text_2 = "# header comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF + "# comment";
-        // File with a multi-line header and trailer comment
-        String text_3 = "# multi-line" + CRLF + "# header comment"+CRLF+"A,B"+CRLF+"1,2"+CRLF+"# multi-line"+CRLF+"# comment";
-        // Format with auto-detected header
-        CSVFormat format_a = CSVFormat.Builder.create(CSVFormat.DEFAULT).setCommentMarker('#').setHeader().build();
-        // Format with explicit header
-        CSVFormat format_b = CSVFormat.Builder.create(CSVFormat.DEFAULT)
-                .setSkipHeaderRecord(true)
-                .setCommentMarker('#')
-                .setHeader("A","B")
-                .build();
-        // Format with explicit header that does not skip the header line
-        CSVFormat format_c = CSVFormat.Builder.create(CSVFormat.DEFAULT)
-                .setCommentMarker('#')
-                .setHeader("A","B")
-                .build();
 
-        try (CSVParser parser = CSVParser.parse(text_1, format_a)) {
+    @Test
+    public void testGetTrailerComment_HeaderComment1() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();
             assertFalse(parser.hasTrailerComment());
             assertNull(parser.getTrailerComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_2, format_a)) {
+    }
+    @Test
+    public void testGetTrailerComment_HeaderTrailerComment1() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_TRAILER_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();
             assertTrue(parser.hasTrailerComment());
             assertEquals("comment", parser.getTrailerComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_3, format_a)) {
+    }
+    @Test
+    public void testGetTrailerComment_MultilineComment() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_MULTILINE_HEADER_TRAILER_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();
             assertTrue(parser.hasTrailerComment());
             assertEquals("multi-line"+LF+"comment", parser.getTrailerComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_1, format_b)) {
+    }
+    @Test
+    public void testGetTrailerComment_HeaderComment2() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER)) {
             parser.getRecords();
             assertFalse(parser.hasTrailerComment());
             assertNull(parser.getTrailerComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_2, format_b)) {
+    }
+    @Test
+    public void testGetTrailerComment_HeaderTrailerComment2() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_TRAILER_COMMENT, FORMAT_EXPLICIT_HEADER)) {
             parser.getRecords();
             assertTrue(parser.hasTrailerComment());
             assertEquals("comment", parser.getTrailerComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_1, format_c)) {
+    }
+    @Test
+    public void testGetTrailerComment_HeaderComment3() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {
             parser.getRecords();
             assertFalse(parser.hasTrailerComment());
             assertNull(parser.getTrailerComment());
         }
-        try (CSVParser parser = CSVParser.parse(text_2, format_c)) {
+    }
+    @Test
+    public void testGetTrailerComment_HeaderTrailerComment3() throws IOException {
+        try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_TRAILER_COMMENT, FORMAT_EXPLICIT_HEADER_NOSKIP)) {
             parser.getRecords();
             assertTrue(parser.hasTrailerComment());
             assertEquals("comment", parser.getTrailerComment());

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1375,6 +1375,7 @@ public class CSVParserTest {
 
         parser.close();
     }
+
     // CSV with no header comments
     static private final String CSV_INPUT_NO_COMMENT = "A,B"+CRLF+"1,2"+CRLF;
     // CSV with a header comment
@@ -1399,7 +1400,6 @@ public class CSVParserTest {
 
     @Test
     public void testGetHeaderComment_NoComment1() throws IOException {
-
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_NO_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();
             // Expect no header comment


### PR DESCRIPTION
Add accessors for header comments (before the header row)
and trailer comments (after the last record)
Also add javadoc and tests

See https://issues.apache.org/jira/browse/CSV-304