### PR TITLE
Validate input to setDelimiter(String) for empty string

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -346,6 +346,9 @@ public final class CSVFormat implements Serializable {
             if (containsLineBreak(delimiter)) {
                 throw new IllegalArgumentException("The delimiter cannot be a line break");
             }
+            if (delimiter.isEmpty()) {
+                throw new IllegalArgumentException("The delimiter cannot be empty");
+            }
             this.delimiter = delimiter;
             return this;
         }

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -1569,4 +1569,9 @@ public class CSVFormatTest {
         final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.withSystemRecordSeparator();
         assertEquals(System.lineSeparator(), formatWithRecordSeparator.getRecordSeparator());
     }
+
+    @Test
+    public void testDelimiterEmptyStringThrowsException1() {
+        assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setDelimiter("").build());
+    }
 }


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <m.faryma@partner.samsung.com>

The addition of String delimiter support opened a new opportunity to set the delimiter as empty string. This situation will result in `NegativeArraySizeException` (see example below). I propose to enhance argument checking in `setDelimiter(String delimiter)` to get explicit and helpful exception in such case. 

Log:
```
Exception in thread "main" java.lang.NegativeArraySizeException: -1
        at org.apache.commons.csv.Lexer.<init>(Lexer.java:75)
        at org.apache.commons.csv.CSVParser.<init>(CSVParser.java:435)
        at org.apache.commons.csv.CSVParser.<init>(CSVParser.java:403)
        at org.apache.commons.csv.CSVParser.parse(CSVParser.java:303)
        at Test.main(Test.java:10)
```
Test code:
```
import org.apache.commons.csv.CSVFormat;
import org.apache.commons.csv.CSVParser;

import java.io.StringReader;

public class Test {
    public static void main(String[] args) throws Exception {

        CSVParser.parse("abcd", CSVFormat.Builder.create().setDelimiter("").build());
    }
}
```