### PR TITLE
Add support for trailing text after the closing quote, and EOF without a final closing quote, for Excel compatibility

### DIFF
--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -57,6 +57,7 @@ final class Lexer implements Closeable {
 
     private final boolean ignoreSurroundingSpaces;
     private final boolean ignoreEmptyLines;
+    private final boolean allowTrailingText;
 
     /** The input stream */
     private final ExtendedBufferedReader reader;
@@ -72,6 +73,7 @@ final class Lexer implements Closeable {
         this.commentStart = mapNullToDisabled(format.getCommentMarker());
         this.ignoreSurroundingSpaces = format.getIgnoreSurroundingSpaces();
         this.ignoreEmptyLines = format.getIgnoreEmptyLines();
+        this.allowTrailingText = format.getAllowTrailingText();
         this.delimiterBuf = new char[delimiter.length - 1];
         this.escapeDelimiterBuf = new char[2 * delimiter.length - 1];
     }
@@ -364,10 +366,14 @@ final class Lexer implements Closeable {
                             token.type = EORECORD;
                             return token;
                         }
-                        if (!Character.isWhitespace((char)c)) {
-                            // error invalid char between token and next delimiter
-                            throw new IOException("(line " + getCurrentLineNumber() +
-                                    ") invalid char between encapsulated token and delimiter");
+                        if (allowTrailingText) {
+                            token.content.append((char) c);
+                        } else {
+                            if (!Character.isWhitespace((char)c)) {
+                                // error invalid char between token and next delimiter
+                                throw new IOException("(line " + getCurrentLineNumber() +
+                                        ") invalid char between encapsulated token and delimiter");
+                            }
                         }
                     }
                 }

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -441,7 +441,20 @@ public class LexerTest {
             assertThat(parser.nextToken(new Token()), matches(EOF, "a b \"\""));
         }
         try (final Lexer parser = createLexer(code, CSVFormat.Builder.create().setAllowTrailingText(false).build())) {
-            assertThrows(IOException.class, () -> lexer.nextToken(new Token()));
+            assertThrows(IOException.class, () -> parser.nextToken(new Token()));
+        }
+    }
+
+    @Test
+    public void testEOFWithoutClosingQuote() throws Exception {
+        final String code = "a,\"b";
+        try (final Lexer parser = createLexer(code, CSVFormat.Builder.create().setAllowEofWithoutClosingQuote(true).build())) {
+            assertThat(parser.nextToken(new Token()), matches(TOKEN, "a"));
+            assertThat(parser.nextToken(new Token()), matches(EOF, "b"));
+        }
+        try (final Lexer parser = createLexer(code, CSVFormat.Builder.create().setAllowEofWithoutClosingQuote(false).build())) {
+            assertThat(parser.nextToken(new Token()), matches(TOKEN, "a"));
+            assertThrows(IOException.class, () -> parser.nextToken(new Token()));
         }
     }
 }

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -431,4 +431,17 @@ public class LexerTest {
         lexer.trimTrailingSpaces(buffer);
         assertThat(lexer.nextToken(new Token()), matches(EOF, ""));
     }
+
+    @Test
+    public void testTrailingTextAfterQuote() throws Exception {
+        final String code = "\"a\" b,\"a\" \" b,\"a\" b \"\"";
+        try (final Lexer parser = createLexer(code, CSVFormat.Builder.create().setAllowTrailingText(true).build())) {
+            assertThat(parser.nextToken(new Token()), matches(TOKEN, "a b"));
+            assertThat(parser.nextToken(new Token()), matches(TOKEN, "a \" b"));
+            assertThat(parser.nextToken(new Token()), matches(EOF, "a b \"\""));
+        }
+        try (final Lexer parser = createLexer(code, CSVFormat.Builder.create().setAllowTrailingText(false).build())) {
+            assertThrows(IOException.class, () -> lexer.nextToken(new Token()));
+        }
+    }
 }


### PR DESCRIPTION
As per issue https://issues.apache.org/jira/browse/CSV-141 and based on what we did in Apache OpenOffice https://bz.apache.org/ooo/show_bug.cgi?id=126805

This adds a setting, allowTrailingText (for lack of a better name) that allows CSV fields to have trailing text after the closing quote, up to the next separator, which can contain anything except the separator character, and this extra text is appended as-is to the field contents (any further quoting is ignored). This is exactly how Excel behaves.

As this is a non-standard setting with surprising behaviour, I've made it off by default. Only CSVFormat.EXCEL has it on by default.

This doesn't fully fix CSV-141 yet as that has line ending issues too, but I'd like to investigate how Excel handles that first.