### PR TITLE
disable spdx as it forks verify phase execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,30 @@
         <coveralls.skip>true</coveralls.skip>
       </properties>
     </profile>
+
+    <profile>
+      <id>skip-spdx</id>
+      <activation>
+        <property><name>!enable-spdx</name></property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.spdx</groupId>
+            <artifactId>spdx-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-spdx</id>
+                <goals>
+                  <goal>createSPDX</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
when building current HEAD, I found this surprising output at the end, after the classical:
```
[INFO] --- maven-jar-plugin:3.3.0:test-jar (default) @ commons-csv ---
[INFO] Building jar: /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-tests.jar
[INFO] 
[INFO] --- maven-source-plugin:3.2.1:jar-no-fork (create-source-jar) @ commons-csv ---
[INFO] Building jar: /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-sources.jar
[INFO] 
[INFO] --- maven-source-plugin:3.2.1:test-jar-no-fork (create-source-jar) @ commons-csv ---
[INFO] Building jar: /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-test-sources.jar

...

[INFO] >>> spdx-maven-plugin:0.6.3:createSPDX (build-spdx) > verify @ commons-csv >>>
[INFO] 
[INFO] --- maven-enforcer-plugin:3.1.0:enforce (enforce-maven-version) @ commons-csv ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.1.0:enforce (enforce-java-version) @ commons-csv ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.1.0:enforce (enforce-maven-3) @ commons-csv ---
[INFO] 
[INFO] --- apache-rat-plugin:0.15:check (rat-check) @ commons-csv ---
[INFO] Enabled default license matchers.
[INFO] Will parse SCM ignores for exclusions...
[INFO] Parsing exclusions from /home/herve/tmp/commons-csv/.gitignore
[INFO] Finished adding exclusions from SCM ignore files.
[INFO] 74 implicit excludes.
[INFO] 34 explicit excludes.
[INFO] 83 resources included
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 76 licenses.
[INFO] 
[INFO] --- build-helper-maven-plugin:3.3.0:parse-version (parse-version) @ commons-csv ---
[INFO] 
[INFO] --- maven-antrun-plugin:3.1.0:run (javadoc.resources) @ commons-csv ---
[INFO] Executing tasks
[INFO] Executed tasks
[INFO] 
[INFO] --- maven-remote-resources-plugin:1.7.0:process (process-resource-bundles) @ commons-csv ---
[INFO] Skipping remote resources execution.
[INFO] 
[INFO] --- buildnumber-maven-plugin:3.0.0:create (default) @ commons-csv ---
[INFO] Executing: /bin/sh -c cd '/home/herve/tmp/commons-csv' && 'git' 'rev-parse' '--verify' 'HEAD'
[INFO] Working directory: /home/herve/tmp/commons-csv
[INFO] Storing buildNumber: null at timestamp: 1675786441076
[INFO] Storing buildScmBranch: master
[INFO] 
[INFO] --- maven-resources-plugin:3.3.0:resources (default-resources) @ commons-csv ---
[INFO] skip non existing resourceDirectory /home/herve/tmp/commons-csv/src/main/resources
[INFO] Copying 2 resources to META-INF
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.1:compile (default-compile) @ commons-csv ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 12 source files to /home/herve/tmp/commons-csv/target/classes
[INFO] 
[INFO] --- maven-bundle-plugin:5.1.8:manifest (bundle-manifest) @ commons-csv ---
[INFO] Writing manifest: /home/herve/tmp/commons-csv/target/osgi/MANIFEST.MF
[INFO] 
[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ commons-csv ---
[INFO] Copying 22 resources
[INFO] Copying 2 resources to META-INF
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.1:testCompile (default-testCompile) @ commons-csv ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 35 source files to /home/herve/tmp/commons-csv/target/test-classes
[INFO] /home/herve/tmp/commons-csv/src/test/java/org/apache/commons/csv/LexerTest.java: Some input files use or override a deprecated API.
[INFO] /home/herve/tmp/commons-csv/src/test/java/org/apache/commons/csv/LexerTest.java: Recompile with -Xlint:deprecation for details.
[INFO] 
[INFO] --- animal-sniffer-maven-plugin:1.22:check (checkAPIcompatibility) @ commons-csv ---
[INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.8:prepare-agent (prepare-agent) @ commons-csv ---
[INFO] argLine set to -javaagent:/home/herve/.m2/repository/org/jacoco/org.jacoco.agent/0.8.8/org.jacoco.agent-0.8.8-runtime.jar=destfile=/home/herve/tmp/commons-csv/target/jacoco.exec
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M7:test (default-test) @ commons-csv ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- maven-jar-plugin:3.3.0:jar (default-jar) @ commons-csv ---
[INFO] Building jar: /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-site-plugin:3.12.1:attach-descriptor (attach-descriptor) @ commons-csv ---
[INFO] Skipping because packaging 'jar' is not pom.
[INFO] 
[INFO] --- maven-jar-plugin:3.3.0:test-jar (default) @ commons-csv ---
[INFO] Building jar: /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-tests.jar
[WARNING] artifact org.apache.commons:commons-csv:test-jar:tests:1.10.1-SNAPSHOT already attached, replace previous instance
[INFO] 
[INFO] --- maven-source-plugin:3.2.1:jar-no-fork (create-source-jar) @ commons-csv ---
[WARNING] artifact org.apache.commons:commons-csv:java-source:sources:1.10.1-SNAPSHOT already attached, replace previous instance
[INFO] 
[INFO] --- maven-source-plugin:3.2.1:test-jar-no-fork (create-source-jar) @ commons-csv ---
[WARNING] artifact org.apache.commons:commons-csv:java-source:test-sources:1.10.1-SNAPSHOT already attached, replace previous instance
[INFO] 
[INFO] --- cyclonedx-maven-plugin:2.7.3:makeBom (make-bom) @ commons-csv ---
[INFO] CycloneDX: Parameters
[INFO] ------------------------------------------------------------------------
[INFO] schemaVersion          : 1.4
[INFO] includeBomSerialNumber : true
[INFO] includeCompileScope    : true
[INFO] includeProvidedScope   : true
[INFO] includeRuntimeScope    : true
[INFO] includeTestScope       : false
[INFO] includeSystemScope     : true
[INFO] includeLicenseText     : false
[INFO] outputReactorProjects  : true
[INFO] outputFormat           : all
[INFO] outputName             : commons-csv-1.10.1-SNAPSHOT-bom
[INFO] ------------------------------------------------------------------------
[INFO] CycloneDX: Resolving Dependencies
[INFO] CycloneDX: Creating BOM
[INFO] CycloneDX: Writing BOM (XML): /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-bom.xml
[INFO] CycloneDX: Validating BOM (XML): /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-bom.xml
[WARNING] artifact org.apache.commons:commons-csv:xml:cyclonedx:1.10.1-SNAPSHOT already attached, replace previous instance
[INFO] CycloneDX: Writing BOM (JSON): /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-bom.json
[INFO] CycloneDX: Validating BOM (JSON): /home/herve/tmp/commons-csv/target/commons-csv-1.10.1-SNAPSHOT-bom.json
[WARNING] artifact org.apache.commons:commons-csv:json:cyclonedx:1.10.1-SNAPSHOT already attached, replace previous instance
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.8:check (check) @ commons-csv ---
[INFO] Skipping JaCoCo execution due to missing execution data file:/home/herve/tmp/commons-csv/target/jacoco.exec
[INFO] 
[INFO] <<< spdx-maven-plugin:0.6.3:createSPDX (build-spdx) < verify @ commons-csv <<<
[INFO] 
[INFO] 
[INFO] --- spdx-maven-plugin:0.6.3:createSPDX (build-spdx) @ commons-csv ---
[INFO] Creating SPDX File /home/herve/tmp/commons-csv/target/site/org.apache.commons_commons-csv-1.10.1-SNAPSHOT.spdx.json
[WARNING] Unable to map maven licenses to a declared license.  Using NOASSERTION
```

the build is basically run twice, because `spdx-maven-plugin:0.6.3:createSPDX` forks an execution = 
```
[INFO] >>> spdx-maven-plugin:0.6.3:createSPDX (build-spdx) > verify @ commons-csv >>>

... forked execution ...

[INFO] <<< spdx-maven-plugin:0.6.3:createSPDX (build-spdx) < verify @ commons-csv <<<
```


in this PR, I disabled the spdx plugin by default, which makes the build back to normal execution when running `mvn clean verify`

spdx plugin can be re-enabled by ignoring the profile with `mvn clean verify -Denable-spdx`

IMHO, this plugin is causing harm to the build:
- double execution of goals
- and "of course" warning because trying to attach again on the second execution

it should probably be dropped from parent POM...