### PR TITLE
(doc): Document duplicate header behavior

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -88,7 +88,7 @@ public final class CSVRecord implements Serializable, Iterable<String> {
     }
 
     /**
-     * Returns a value by name.
+     * Returns a value by name. If multiple instances of the header name exists, only the last occurence is returned.
      *
      * <p>
      * Note: This requires a field mapping obtained from the original parser.
@@ -311,7 +311,9 @@ public final class CSVRecord implements Serializable, Iterable<String> {
     }
 
     /**
-     * Copies this record into a new Map of header name to record value.
+     * Copies this record into a new Map of header name to record value. If multiple instances of a header name exists,
+     * only the last occurence is mapped.
+     *
      * <p>
      * Editing the map does not update this instance.
      * </p>

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -339,6 +340,37 @@ public class CSVRecordTest {
         assertTrue(recordWithHeader.toString().contains("comment="));
         assertTrue(recordWithHeader.toString().contains("recordNumber="));
         assertTrue(recordWithHeader.toString().contains("values="));
+    }
+
+    @Test
+    public void testDuplicateHeaderGet() throws IOException {
+        final String csv = "A,A,B,B\n1,2,5,6\n";
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setHeader().build();
+
+        try (final CSVParser parser = CSVParser.parse(csv, format)) {
+            final CSVRecord record = parser.nextRecord();
+
+            assertAll("Test that it gets the last instance of a column when there are duplicate headings",
+                () -> assertEquals("2", record.get("A")),
+                () -> assertEquals("6", record.get("B"))
+            );
+        }
+    }
+
+    @Test
+    public void testDuplicateHeaderToMap() throws IOException {
+        final String csv = "A,A,B,B\n1,2,5,6\n";
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setHeader().build();
+
+        try (final CSVParser parser = CSVParser.parse(csv, format)) {
+            final CSVRecord record = parser.nextRecord();
+            final Map<String, String> map = record.toMap();
+
+            assertAll("Test that it gets the last instance of a column when there are duplicate headings",
+                () -> assertEquals("2", map.get("A")),
+                () -> assertEquals("6", map.get("B"))
+            );
+        }
     }
 
     private void validateMap(final Map<String, String> map, final boolean allowsNulls) {


### PR DESCRIPTION
A while back we discussed duplicate header behavior, and in the comments thought we should define what happens when one tries to get from a `CSVRecord`/`Map<String, String>` when this occurs.

Relevant comments:
* https://github.com/apache/commons-csv/pull/114#issuecomment-874321915
* https://github.com/apache/commons-csv/pull/114#issuecomment-876858602

I reviewed the code and manually tested to discover the current behavior:

* Adds two test cases that reinforce the current behavior.
* Updates the docstrings of `CSVRecord#get` and `CSVRecord#toMap` to state how this is handled.

---

It may be that instead of this, we may want to instead define a different behavior before we add documentation and tests to cover this case.

I'm honestly not sure what the expected behavior would be for this. I'm tempted to say that it should throw an exception in this instance. :thinking:

I'm not aware of the use-case for having duplicate headings in the first place, but I assume there is a reason for it. But I definitely don't see why one would use methods like `#get` or `#toMap` in cases that they know they have duplicate headers.

Maybe if the first and last index of the given header name differs, throw an exception?