### PR TITLE
[CSV-306] replace deprecated method in user guide, update external link

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -29,12 +29,12 @@ limitations under the License.
     <li>Microsoft Excel</li>
     <li><a href="http://www.ibm.com/support/knowledgecenter/SSBJG3_2.5.0/com.ibm.gen_busug.doc/c_fgl_InOutSql_UNLOAD.htm">Informix UNLOAD</a></li>
     <li><a href="http://www.ibm.com/support/knowledgecenter/SSBJG3_2.5.0/com.ibm.gen_busug.doc/c_fgl_InOutSql_UNLOAD.htm">Informix UNLOAD CSV</a></li>
-    <li><a href="http://dev.mysql.com/doc/refman/5.0/en/mysqldump-delimited-text.html">MySQL</a></li>
+    <li><a href="https://dev.mysql.com/doc/refman/8.0/en/mysqldump-delimited-text.html">MySQL</a></li>
     <li><a href="https://docs.oracle.com/database/121/SUTIL/GUID-D1762699-8154-40F6-90DE-EFB8EB6A9AB0.htm#SUTIL4217">Oracle</a></li>
     <li><a href="https://www.postgresql.org/docs/current/static/sql-copy.html">PostgreSQL CSV</a></li>
     <li><a href="https://www.postgresql.org/docs/current/static/sql-copy.html">PostgreSQL Text</a></li>
-    <li><a href="http://tools.ietf.org/html/rfc4180">RFC 4180</a></li>
-    <li><a href="http://en.wikipedia.org/wiki/Tab-separated_values">TDF</a></li>
+    <li><a href="https://datatracker.ietf.org/doc/html/rfc4180">RFC 4180</a></li>
+    <li><a href="https://en.wikipedia.org/wiki/Tab-separated_values">TDF</a></li>
   </ul>
   </p>
   <p>Custom formats can be created using a fluent style API.</p>
@@ -117,13 +117,13 @@ For previous releases, see the <a href="https://archive.apache.org/dist/commons/
   <p>Commons CSV was started to unify a common and simple interface for reading and writing CSV files under an ASL license. It has been bootstrapped by a code donation from Netcetera in Switzerland. There are three pre-existing BSD compatible CSV parsers which this component will hopefully make redundant (authors willing): </p>
   <ul>
     <li><a href="http://kasparov.skife.org/csv/">Skife CSV</a></li>
-    <li><a href="http://opencsv.sourceforge.net/">Open CSV</a></li>
+    <li><a href="https://opencsv.sourceforge.net/">Open CSV</a></li>
     <li><a href="http://www.osjava.org/genjava/multiproject/gj-csv/">Genjava CSV</a></li>
   </ul>
   <p>In addition to the code from Netcetera (org.apache.commons.csv), Martin van den Bemt has added an additional writer API. </p>
   <p>Other CSV implementations: </p>
   <ul>
-    <li><a href="http://supercsv.sourceforge.net/">Super CSV</a></li>
+    <li><a href="https://super-csv.github.io/super-csv/index.html">Super CSV</a></li>
   </ul>
 </section>
 

--- a/src/site/xdoc/user-guide.xml
+++ b/src/site/xdoc/user-guide.xml
@@ -44,7 +44,7 @@ limitations under the License.
         <dt><a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#ORACLE">ORACLE<sup>1.6</sup></a></dt><dd>Default Oracle format used by the SQL*Loader utility.</dd>
         <dt><a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#POSTGRESSQL_CSV">POSTGRESSQL_CSV<sup>1.5</sup></a></dt><dd>Default PostgreSQL CSV format used by the COPY operation.</dd>
         <dt><a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#POSTGRESSQL_TEXT">POSTGRESSQL_TEXT<sup>1.5</sup></a></dt><dd>Default PostgreSQL text format used by the COPY operation.</dd>
-        <dt><a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#RFC4180">RFC-4180</a></dt><dd>The RFC-4180 format defined by <a href="https://tools.ietf.org/html/rfc4180">RFC-4180</a>.</dd>
+        <dt><a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#RFC4180">RFC-4180</a></dt><dd>The RFC-4180 format defined by <a href="https://datatracker.ietf.org/doc/html/rfc4180">RFC-4180</a>.</dd>
         <dt><a href="https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.html#TDF">TDF</a></dt><dd>A tab delimited format.</dd>
       </dl>
 
@@ -101,7 +101,7 @@ public InputStreamReader newReader(final InputStream inputStream) {
       Apache Commons CSV provides several ways to access record values.
       The simplest way is to access values by their index in the record.
       However, columns in CSV files often have a name, for example: ID, CustomerNo, Birthday, etc.
-      The CSVFormat class provides an API for specifing these <i>header</i> names and CSVRecord on
+      The CSVFormat class provides an API for specifying these <i>header</i> names and CSVRecord on
       the other hand has methods to access values by their corresponding header name.
 
       <subsection name="Accessing column values by index">
@@ -149,7 +149,7 @@ for (CSVRecord record : records) {
         Some CSV files define header names in their first record. If configured, Apache Commons CSV can parse
         the header names from the first record:
         <source>Reader in = new FileReader(&quot;path/to/file.csv&quot;);
-Iterable&lt;CSVRecord&gt; records = CSVFormat.RFC4180.withFirstRecordAsHeader().parse(in);
+Iterable&lt;CSVRecord&gt; records = CSVFormat.RFC4180.withHeader().withSkipHeaderRecord(true).parse(in);
 for (CSVRecord record : records) {
     String id = record.get("ID");
     String customerNo = record.get("CustomerNo");


### PR DESCRIPTION
In addition, I found some dead link in https://commons.apache.org/proper/commons-csv/ like
[Genjava CSV](http://www.osjava.org/genjava/multiproject/gj-csv/)
[Informix UNLOAD](http://www.ibm.com/support/knowledgecenter/SSBJG3_2.5.0/com.ibm.gen_busug.doc/c_fgl_InOutSql_UNLOAD.htm)
[Informix UNLOAD CSV](http://www.ibm.com/support/knowledgecenter/SSBJG3_2.5.0/com.ibm.gen_busug.doc/c_fgl_InOutSql_UNLOAD.htm)
