### PR TITLE
[CSV-310] Misleading error message when QuoteMode set to None

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2449,7 +2449,7 @@ public final class CSVFormat implements Serializable {
         }
 
         if (escapeCharacter == null && quoteMode == QuoteMode.NONE) {
-            throw new IllegalArgumentException("No quotes mode set but no escape character is set");
+            throw new IllegalArgumentException("Quote mode set to NONE but no escape character is set");
         }
 
         // Validate headers

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -1477,4 +1477,17 @@ public class CSVFormatTest {
         final CSVFormat formatWithRecordSeparator = CSVFormat.DEFAULT.withSystemRecordSeparator();
         assertEquals(System.lineSeparator(), formatWithRecordSeparator.getRecordSeparator());
     }
+
+    @Test
+    public void testQuoteModeNoneShouldReturnMeaningfulExceptionMessage() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            CSVFormat.DEFAULT.builder()
+                    .setHeader("Col1", "Col2", "Col3", "Col4")
+                    .setQuoteMode(QuoteMode.NONE)
+                    .build();
+        });
+        String actualMessage = exception.getMessage();
+        String expectedMessage = "Quote mode set to NONE but no escape character is set";
+        assertEquals(expectedMessage, actualMessage);
+    }
 }


### PR DESCRIPTION
See related Jira issue: https://issues.apache.org/jira/browse/CSV-310

When we try to print CSV content using the `CSVFormat` and `CSVPrinter`, we can ger it done with following sample code.

```
public void testHappyPath() throws IOException {
    CSVFormat csvFormat = CSVFormat.DEFAULT.builder()
            .setHeader("Col1", "Col2", "Col3", "Col4")
            .setQuoteMode(QuoteMode.NONE)
            .setEscape('#')
            .build();

    CSVPrinter printer = new CSVPrinter(System.out, csvFormat);

    List<String[]> temp = new ArrayList<>();

    temp.add(new String[] { "rec1", "rec2\"", "", "rec4" });
    temp.add(new String[] { "", "rec6", "rec7", "rec8" });

    for (String[] temp1 : temp) {
        printer.printRecord(temp1);
    }
    printer.close();
}
```

In above sample I have used `setQuoteMode(QuoteMode.NONE)`. However, if we do not set the escape character using `setEscape('#')` then it would result in following exception.
`java.lang.IllegalArgumentException: No quotes mode set but no escape character is set.`

At first, I was wondering why I was getting this error. Then I looked into the source and figured out that `CSVFormat.printWithEscapes()` method internally using `getEscapeCharacter().charValue()` method to print records.

However, the error message which we are getting is sort of misleading. It implies that the code has not set any quote mode even though we set it.
Simple and more meaningful exception message could be: `Quote mode set to NONE but no escape character is set`.