### PR TITLE
MongoDB CSV empty first column parsing fix

### DIFF
--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -334,18 +334,7 @@ final class Lexer implements Closeable {
         while (true) {
             c = reader.read();
 
-            if (isEscape(c)) {
-                if (isEscapeDelimiter()) {
-                    token.content.append(delimiter);
-                } else {
-                    final int unescaped = readEscape();
-                    if (unescaped == EOF) { // unexpected char after escape
-                        token.content.append((char) c).append((char) reader.getLastChar());
-                    } else {
-                        token.content.append((char) unescaped);
-                    }
-                }
-            } else if (isQuoteChar(c)) {
+            if (isQuoteChar(c)) {
                 if (isQuoteChar(reader.lookAhead())) {
                     // double or escaped encapsulator -> add single encapsulator to token
                     c = reader.read();
@@ -374,6 +363,17 @@ final class Lexer implements Closeable {
                             throw new IOException(String.format("Invalid char between encapsulated token and delimiter at line: %,d, position: %,d",
                                     getCurrentLineNumber(), getCharacterPosition()));
                         }
+                    }
+                }
+            } else if (isEscape(c)) {
+                if (isEscapeDelimiter()) {
+                    token.content.append(delimiter);
+                } else {
+                    final int unescaped = readEscape();
+                    if (unescaped == EOF) { // unexpected char after escape
+                        token.content.append((char) c).append((char) reader.getLastChar());
+                    } else {
+                        token.content.append((char) unescaped);
                     }
                 }
             } else if (isEndOfFile(c)) {

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1564,18 +1564,24 @@ public class CSVParserTest {
 
     @Test
     public void testParsingPrintedEmptyFirstColumn() throws Exception {
+        String[][] lines = new String[][] {
+                {"a", "b"},
+                {"", "x"}
+        };
         Exception firstException = null;
         for (CSVFormat.Predefined format : CSVFormat.Predefined.values()) {
             try {
                 StringWriter buf = new StringWriter();
                 try (CSVPrinter printer = new CSVPrinter(buf, format.getFormat())) {
-                    printer.printRecord("a", "b"); // header
-                    printer.printRecord("", "x");  // empty first column
-                }
-                try (CSVParser csvRecords = new CSVParser(new StringReader(buf.toString()), format.getFormat().builder().setHeader().build())) {
-                    for (CSVRecord csvRecord : csvRecords) {
-                        assertNotNull(csvRecord);
+                    for (String[] line : lines) {
+                        printer.printRecord((Object[]) line);
                     }
+                }
+                try (CSVParser csvRecords = new CSVParser(new StringReader(buf.toString()), format.getFormat())) {
+                    for (String[] line : lines) {
+                        assertArrayEquals(line, csvRecords.nextRecord().values());
+                    }
+                    assertNull(csvRecords.nextRecord());
                 }
             } catch (Exception | Error e) {
                 Exception detailedException = new RuntimeException("format: " + format, e);

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1562,6 +1562,35 @@ public class CSVParserTest {
             assertEquals(3, record.size());
         }}
 
+    @Test
+    public void testParsingPrintedEmptyFirstColumn() throws Exception {
+        Exception firstException = null;
+        for (CSVFormat.Predefined format : CSVFormat.Predefined.values()) {
+            try {
+                StringWriter buf = new StringWriter();
+                try (CSVPrinter printer = new CSVPrinter(buf, format.getFormat())) {
+                    printer.printRecord("a", "b"); // header
+                    printer.printRecord("", "x");  // empty first column
+                }
+                try (CSVParser csvRecords = new CSVParser(new StringReader(buf.toString()), format.getFormat().builder().setHeader().build())) {
+                    for (CSVRecord csvRecord : csvRecords) {
+                        assertNotNull(csvRecord);
+                    }
+                }
+            } catch (Exception | Error e) {
+                Exception detailedException = new RuntimeException("format: " + format, e);
+                if (firstException == null) {
+                    firstException = detailedException;
+                } else {
+                    firstException.addSuppressed(detailedException);
+                }
+            }
+        }
+
+        if (firstException != null)
+            throw firstException;
+    }
+
     private void validateLineNumbers(final String lineSeparator) throws IOException {
         try (final CSVParser parser = CSVParser.parse("a" + lineSeparator + "b" + lineSeparator + "c", CSVFormat.DEFAULT.withRecordSeparator(lineSeparator))) {
             assertEquals(0, parser.getCurrentLineNumber());


### PR DESCRIPTION
when printed a record with an empty first column with MongoDBCsv predefined format, the csv file cannot be then parsed with the same MongoDBCsv predefined format.

this is due to the conflict between 'escape' and 'quote' character branches in Lexer. They are both set to ' " ' for MongoDBCsv.

fix: in Lexer reordered 'escape' and 'quote' branches.