### PR TITLE
[CSV-293] Add support for multiple null String values

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -229,8 +229,6 @@ public final class CSVFormat implements Serializable {
 
         private Character quoteCharacter;
 
-        private String[] quotedNullStrings;
-
         private QuoteMode quoteMode;
 
         private String recordSeparator;
@@ -265,7 +263,6 @@ public final class CSVFormat implements Serializable {
             this.trailingDelimiter = csvFormat.trailingDelimiter;
             this.trim = csvFormat.trim;
             this.autoFlush = csvFormat.autoFlush;
-            this.quotedNullStrings = csvFormat.quotedNullStrings;
             this.duplicateHeaderMode = csvFormat.duplicateHeaderMode;
         }
 
@@ -709,7 +706,6 @@ public final class CSVFormat implements Serializable {
          */
         public Builder setNullString(final String nullString) {
             this.nullStrings = new String[]{nullString};
-            this.quotedNullStrings = new String[]{quoteCharacter + nullString + quoteCharacter};
             return this;
         }
 
@@ -726,11 +722,6 @@ public final class CSVFormat implements Serializable {
          */
         public Builder setNullStrings(final String[] nullStrings) {
             this.nullStrings = CSVFormat.clone(nullStrings);
-            if (nullStrings != null) {
-                this.quotedNullStrings = Arrays.stream(nullStrings).map(str -> quoteCharacter + str + quoteCharacter).toArray(String[]::new);
-            } else {
-                this.quotedNullStrings = new String[]{quoteCharacter + "" + quoteCharacter};
-            }
             return this;
         }
 
@@ -1496,8 +1487,6 @@ public final class CSVFormat implements Serializable {
     /** Set to null if quoting is disabled. */
     private final Character quoteCharacter;
 
-    private final String[] quotedNullStrings;
-
     private final QuoteMode quoteMode;
 
     /** For output. */
@@ -1533,7 +1522,6 @@ public final class CSVFormat implements Serializable {
         this.trailingDelimiter = builder.trailingDelimiter;
         this.trim = builder.trim;
         this.autoFlush = builder.autoFlush;
-        this.quotedNullStrings = builder.quotedNullStrings;
         this.duplicateHeaderMode = builder.duplicateHeaderMode;
         validate();
     }
@@ -1587,14 +1575,6 @@ public final class CSVFormat implements Serializable {
         this.trailingDelimiter = trailingDelimiter;
         this.trim = trim;
         this.autoFlush = autoFlush;
-        if (nullStrings != null) {
-            this.quotedNullStrings = new String[nullStrings.length];
-            for (int i = 0; i < nullStrings.length; i++) {
-                this.quotedNullStrings[i] = quoteCharacter + nullStrings[i] + quoteCharacter;
-            }
-        } else {
-            this.quotedNullStrings = new String[]{quoteCharacter + "" + quoteCharacter};
-        }
         this.duplicateHeaderMode = duplicateHeaderMode;
         validate();
     }
@@ -1652,9 +1632,9 @@ public final class CSVFormat implements Serializable {
                 ignoreEmptyLines == other.ignoreEmptyLines && ignoreHeaderCase == other.ignoreHeaderCase &&
                 ignoreSurroundingSpaces == other.ignoreSurroundingSpaces && lenientEof == other.lenientEof &&
                 Arrays.equals(nullStrings, other.nullStrings) && Objects.equals(quoteCharacter, other.quoteCharacter) &&
-                quoteMode == other.quoteMode && Arrays.equals(quotedNullStrings, other.quotedNullStrings) &&
-                Objects.equals(recordSeparator, other.recordSeparator) && skipHeaderRecord == other.skipHeaderRecord &&
-                trailingData == other.trailingData && trailingDelimiter == other.trailingDelimiter && trim == other.trim;
+                quoteMode == other.quoteMode && Objects.equals(recordSeparator, other.recordSeparator) &&
+                skipHeaderRecord == other.skipHeaderRecord && trailingData == other.trailingData &&
+                trailingDelimiter == other.trailingDelimiter && trim == other.trim;
     }
 
     private void escape(final char c, final Appendable appendable) throws IOException {
@@ -1992,7 +1972,6 @@ public final class CSVFormat implements Serializable {
         result = prime * result + Arrays.hashCode(headerComments);
         result = prime * result + Arrays.hashCode(headers);
         result = prime * result + Arrays.hashCode(nullStrings);
-        result = prime * result + Arrays.hashCode(quotedNullStrings);
         result = prime * result + Objects.hash(allowMissingColumnNames, autoFlush, commentMarker, delimiter, duplicateHeaderMode, escapeCharacter,
                 ignoreEmptyLines, ignoreHeaderCase, ignoreSurroundingSpaces, lenientEof, quoteCharacter, quoteMode,
                 recordSeparator, skipHeaderRecord, trailingData, trailingDelimiter, trim);
@@ -2154,7 +2133,7 @@ public final class CSVFormat implements Serializable {
             if (null == nullStrings) {
                 charSequence = Constants.EMPTY;
             } else if (QuoteMode.ALL == quoteMode) {
-                charSequence = quotedNullStrings[0];
+                charSequence = quoteCharacter.charValue() + nullStrings[0] + quoteCharacter.charValue();
             } else {
                 charSequence = nullStrings[0];
             }

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -659,14 +659,14 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
      */
     private String handleNull(final String input) {
         final boolean isQuoted = reusableToken.isQuoted;
-        final String nullString = format.getNullString();
+        final String[] nullStrings = format.getNullStrings();
         final boolean strictQuoteMode = isStrictQuoteMode();
-        if (input.equals(nullString)) {
+        if (nullStrings != null && Arrays.asList(nullStrings).contains(input)) {
             // nullString = NULL(String), distinguish between "NULL" and NULL in ALL_NON_NULL or NON_NUMERIC quote mode
             return strictQuoteMode && isQuoted ? input : null;
         }
         // don't set nullString, distinguish between "" and ,, (absent values) in All_NON_NULL or NON_NUMERIC quote mode
-        return strictQuoteMode && nullString == null && input.isEmpty() && !isQuoted ? null : input;
+        return strictQuoteMode && nullStrings == null && input.isEmpty() && !isQuoted ? null : input;
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -698,7 +698,7 @@ public class CSVFormatTest {
         final CSVFormat format = CSVFormat.RFC4180.withEscape('?').withDelimiter(',').withQuoteMode(QuoteMode.MINIMAL).withRecordSeparator(CRLF).withQuote('"')
                 .withNullString("").withIgnoreHeaderCase(true).withHeaderComments("This is HeaderComments").withHeader("col1", "col2", "col3");
         assertEquals(
-                "Delimiter=<,> Escape=<?> QuoteChar=<\"> QuoteMode=<MINIMAL> NullString=<> RecordSeparator=<" + CRLF
+                "Delimiter=<,> Escape=<?> QuoteChar=<\"> QuoteMode=<MINIMAL> NullStrings=<[]> RecordSeparator=<" + CRLF
                         + "> IgnoreHeaderCase:ignored SkipHeaderRecord:false HeaderComments:[This is HeaderComments] Header:[col1, col2, col3]",
                 format.toString());
     }

--- a/src/test/java/org/apache/commons/csv/issues/JiraCsv293Test.java
+++ b/src/test/java/org/apache/commons/csv/issues/JiraCsv293Test.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.csv.issues;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// Add support for multiple null String values
+public class JiraCsv293Test {
+
+    @Test
+    public void setMultipleNullStrings() throws IOException {
+        final CSVFormat format = CSVFormat.Builder.create().setNullStrings(new String[]{"Aaa", "Bbb"}).build();
+
+        final String code = "Aaa,Bbb,Ccc,Ddd";
+        try (final CSVParser parser = CSVParser.parse(code, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertNull(records.get(0).values()[0]);
+            assertNull(records.get(0).values()[1]);
+            assertNotNull(records.get(0).values()[2]);
+            assertNotNull(records.get(0).values()[3]);
+        }
+    }
+
+    @Test
+    public void setOneNullStringByUsingArray() throws IOException {
+        final CSVFormat format = CSVFormat.Builder.create().setNullStrings(new String[]{"Aaa"}).build();
+
+        final String code = "Aaa,Bbb,Ccc,Ddd";
+        try (final CSVParser parser = CSVParser.parse(code, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertNull(records.get(0).values()[0]);
+            assertNotNull(records.get(0).values()[1]);
+            assertNotNull(records.get(0).values()[2]);
+            assertNotNull(records.get(0).values()[3]);
+        }
+    }
+
+    @Test
+    public void setNullStrings() throws IOException {
+        final CSVFormat format = CSVFormat.Builder.create().setNullStrings(null).build();
+
+        final String code = "Aaa,Bbb,Ccc,Ddd";
+        try (final CSVParser parser = CSVParser.parse(code, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertNotNull(records.get(0).values()[0]);
+            assertNotNull(records.get(0).values()[1]);
+            assertNotNull(records.get(0).values()[2]);
+            assertNotNull(records.get(0).values()[3]);
+        }
+    }
+
+    @Test
+    public void setOneNullString() throws IOException {
+        final CSVFormat format = CSVFormat.Builder.create().setNullString("Aaa").build();
+
+        final String code = "Aaa,Bbb,Ccc,Ddd";
+        try (final CSVParser parser = CSVParser.parse(code, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertNull(records.get(0).values()[0]);
+            assertNotNull(records.get(0).values()[1]);
+            assertNotNull(records.get(0).values()[2]);
+            assertNotNull(records.get(0).values()[3]);
+        }
+    }
+
+    @Test
+    public void getNullStrings() {
+        final CSVFormat format = CSVFormat.Builder.create().build();
+        assertNull(format.getNullStrings());
+
+        final CSVFormat format2 = CSVFormat.Builder.create().setNullString("null").build();
+        assertNotNull(format2.getNullStrings());
+        assertArrayEquals(new String[]{"null"}, format2.getNullStrings());
+
+        final CSVFormat format3 = CSVFormat.Builder.create().setNullStrings(new String[]{"null"}).build();
+        assertNotNull(format3.getNullStrings());
+        assertArrayEquals(new String[]{"null"}, format3.getNullStrings());
+    }
+}


### PR DESCRIPTION
This change satisfies the https://issues.apache.org/jira/browse/CSV-293 issue to support multiple null String values.
- I changed the CSVFormat class to be able to store not only one String representing the null value, but an array of Strings for multiple values.
- I also changed the Builder to handle the array of Strings as null values.
- To be backward compatible, I left the old setNullString(String) API untouched but changed the behavior to store the String in an array as a single value.
- I changed the equals body to use Arrays.equals instead of Object.equals since the String nullString changed to a String[] nullStrings.
- I also changed the calculation of quotedNullString in the first commit, but I completely removed it in the second commit, because It was calculated and assigned in a bunch of places, but was used only in one place, so left the minimum required logic in that print() method.
- Finally, I changed the CSVParser to use the null values set in the CSVFormat.
- Testing:
  - Since the changes are backward compatible no test changed, only the toString as NullString became NullStrings.
  - I created test cases in the issues/JiraCsv293Test for the new multiple null values in case of
    - multiple values are provided
    - one value is provided
    - null is provided
  - I also wrote test cases for the original API.
  - I also write a test for the new getter.