### PR TITLE
Fix documentation for CSVFormat private constructor

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -1528,14 +1528,14 @@ public final class CSVFormat implements Serializable {
      * @param ignoreSurroundingSpaces {@code true} when whitespaces enclosing values should be ignored.
      * @param ignoreEmptyLines        {@code true} when the parser should skip empty lines.
      * @param recordSeparator         the line separator to use for output.
-     * @param nullString              the line separator to use for output.
-     * @param headerComments          the comments to be printed by the Printer before the actual CSV data..
+     * @param nullString              the String to convert to and from {@code null}.
+     * @param headerComments          the comments to be printed by the Printer before the actual CSV data.
      * @param header                  the header.
      * @param skipHeaderRecord        if {@code true} the header row will be skipped.
      * @param allowMissingColumnNames if {@code true} the missing column names are allowed when parsing the header line.
      * @param ignoreHeaderCase        if {@code true} header names will be accessed ignoring case when parsing input.
      * @param trim                    if {@code true} next record value will be trimmed.
-     * @param trailingDelimiter       if {@code true} the trailing delimiter wil be added before record separator (if set)..
+     * @param trailingDelimiter       if {@code true} the trailing delimiter wil be added before record separator (if set).
      * @param autoFlush               if {@code true} the underlying stream will be flushed before closing.
      * @param duplicateHeaderMode     the behavior when handling duplicate headers.
      * @param trailingData            whether reading trailing data is allowed in records, helps Excel compatibility.


### PR DESCRIPTION
- In the CSVFormat one of the private constructors had wrong description for nullString parameter.
- In the same JavaDoc block, I removed the "Two consecutive dots " issues.