### PR TITLE
[CSV-320] Remove Spotbugs Dependency and use exclude-filter instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,6 @@
       <version>${commons.jmh.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <version>${commons.spotbugs.impl.version}</version>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/commons-csv.git</connection>

--- a/src/main/java/org/apache/commons/csv/CSVPrinter.java
+++ b/src/main/java/org/apache/commons/csv/CSVPrinter.java
@@ -40,8 +40,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.io.function.IOStream;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * Prints values in a {@link CSVFormat CSV format}.
  *
@@ -153,7 +151,6 @@ public final class CSVPrinter implements Flushable, Closeable {
      * @throws IOException
      *             If an I/O error occurs
      */
-    @SuppressFBWarnings(value = "AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE", justification = "https://github.com/spotbugs/spotbugs/issues/3428")
     private void endOfRecord() throws IOException {
         println();
         recordCount++;

--- a/src/site/resources/spotbugs/spotbugs-exclude-filter.xml
+++ b/src/site/resources/spotbugs/spotbugs-exclude-filter.xml
@@ -54,5 +54,12 @@
     <Method name="values" />
     <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
+
+  <!-- https://github.com/spotbugs/spotbugs/issues/3428 -->
+  <Match>
+    <Class name="org.apache.commons.csv.CSVPrinter" />
+    <Method name="endOfRecord" />
+    <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE" />
+  </Match>
   
 </FindBugsFilter>


### PR DESCRIPTION
The Spotbugs Dependency introduced by 44b5e6c4c178d1325f2df67467ba6248411f3d9d is toxic.
Even marked as optional, using CsvPrinter requires a compile time dependency.
Since you do have already an exclude list, I suggest to use this instead of polluting the dependencies.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
  https://issues.apache.org/jira/browse/CSV-320
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request.
-- I have copilot enabled but it was just suggesting syntax, the idea came from my head
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
-- there is no code change which would require a test
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

