### PR TITLE
[Javadoc] Clarify behavior of deprecated CSVFormat#withFirstRecordAsHeader()

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2788,7 +2788,7 @@ public final class CSVFormat implements Serializable {
      *                           .get();
      * </pre>
      *
-     * <p><b>Note:</b> Any previously set headers are reset to empty.
+     * <p>Any previously set headers are reset to empty.
      * The resulting format will have {@code skipHeaderRecord = true}.</p>
      *
      * @return A new CSVFormat that is equal to this but using the first record as header.

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2788,6 +2788,9 @@ public final class CSVFormat implements Serializable {
      *                           .get();
      * </pre>
      *
+     * <p><b>Note:</b> Any previously set headers are reset to empty.
+     * The resulting format will have {@code skipHeaderRecord = true}.</p>
+     *
      * @return A new CSVFormat that is equal to this but using the first record as header.
      * @see Builder#setSkipHeaderRecord(boolean)
      * @see Builder#setHeader(String...)


### PR DESCRIPTION

**Description:**
This PR updates the Javadoc of the deprecated method `CSVFormat.withFirstRecordAsHeader()` to clearly explain its behavior.

Previously, the Javadoc was ambiguous: it suggested that calling this method returns a `CSVFormat` “equal to this but using the first record as header,” but it did **not mention** that previously set headers are reset to empty and that `skipHeaderRecord` is automatically set to `true`.

This update adds a note to the Javadoc to make the behavior clear for users, without changing any runtime behavior.

No code behavior is changed; this is purely a documentation improvement.

---


* [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project. 
* [x] Read the [[ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html)](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI). 
* [ ] I **did** use AI to create any part of, or all of, this pull request.  
* [x] Run a successful build using the default [[Maven](https://maven.apache.org/)](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself. 
* [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice. 
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why. 
* [x] Each commit in the pull request should have a meaningful subject line and body. 

