### PR TITLE
Fix surrogate pair byte counting in ExtendedBufferedReader array read

### DIFF
--- a/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
+++ b/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
@@ -109,8 +109,10 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
 
     private long getEncodedCharLength(final char[] buf, final int offset, final int length) throws CharacterCodingException {
         int len = 0;
-        for (int i = offset; i < length; i++) {
-            len += getEncodedCharLength(buf[i]);
+        int previous = lastChar;
+        for (int i = offset; i < offset + length; i++) {
+            len += getEncodedCharLength(buf[i], previous);
+            previous = buf[i];
         }
         return len;
     }
@@ -140,9 +142,9 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
      * @return the byte length of the character.
      * @throws CharacterCodingException if the character cannot be encoded.
      */
-    private int getEncodedCharLength(final int current) throws CharacterCodingException {
+    private int getEncodedCharLength(final int current, final int previous) throws CharacterCodingException {
         final char cChar = (char) current;
-        final char lChar = (char) lastChar;
+        final char lChar = (char) previous;
         if (!Character.isSurrogate(cChar)) {
             return encoder.encode(CharBuffer.wrap(new char[] { cChar })).limit();
         }
@@ -205,7 +207,7 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
             lineNumber++;
         }
         if (encoder != null) {
-            this.bytesRead += getEncodedCharLength(current);
+            this.bytesRead += getEncodedCharLength(current, lastChar);
         }
         lastChar = current;
         position++;
@@ -229,12 +231,12 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
                     lineNumber++;
                 }
             }
+            if (encoder != null) {
+                this.bytesRead += getEncodedCharLength(buf, offset, len);
+            }
             lastChar = buf[offset + len - 1];
         } else if (len == EOF) {
             lastChar = EOF;
-        }
-        if (encoder != null) {
-            this.bytesRead += getEncodedCharLength(buf, offset, len);
         }
         position += len;
         return len;

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -667,6 +667,27 @@ class CSVParserTest {
     }
 
     @Test
+    void testGetBytePositionMultiCharacterDelimiterWithSupplementaryChar() throws IOException {
+        // Delimiter holds a 4-byte (surrogate pair) character; the delimiter tail is consumed through
+        // the char[] read path, where the surrogate halves must be paired with the correct neighbor.
+        final String code = "aa[😀]bb\ncc[😀]dd\n";
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter("[😀]").get();
+        try (CSVParser parser = CSVParser.builder()
+                .setReader(new StringReader(code))
+                .setFormat(format)
+                .setCharset(StandardCharsets.UTF_8)
+                .setTrackBytes(true)
+                .get()) {
+            final Iterator<CSVRecord> it = parser.iterator();
+            final CSVRecord first = it.next();
+            final CSVRecord second = it.next();
+            assertEquals(0, first.getBytePosition());
+            // "aa[😀]bb\n" -> 2 + 1 + 4 + 1 + 2 + 1 = 11 bytes in UTF-8
+            assertEquals(11, second.getBytePosition());
+        }
+    }
+
+    @Test
     void testGetBytePositionWithCharacterOffsetAndMultiBytePrefix() throws Exception {
         final String row0 = "é,x\n";
         final Charset charset = UTF_8;


### PR DESCRIPTION
1. with byte tracking on (setTrackBytes + a charset), read(char[]) advances lastChar to the last buffer char before counting, and the per-char helper reads that field instead of the actual preceding char, so a surrogate pair gets matched against the wrong neighbor (the loop also ran to length instead of offset+length).
2. a 4-byte char taken through the char[] path, e.g. a multi-character delimiter holding a supplementary character, then throws CharacterCodingException out of nextRecord and getBytePosition() goes wrong.

Passed the previous char explicitly and moved the counting ahead of the lastChar update. What happens for a pair split across two buffer reads is covered too since the first char still pairs against the saved lastChar. Added a regression test next to the existing multi-character-delimiter byte-position one.