### PR TITLE
[CSV-326] Escape Reader values with quote and escape

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -51,6 +51,7 @@
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-322">CSVFormat.Builder.setQuote() does not refresh quotedNullString (#2447).</action>
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-324">Lexer.isDelimiter() accepts a partial multi-character delimiter at EOF (#603).</action>
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-325">CSVParser applies characterOffset to bytePosition (#604).</action>
+      <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-326">CSVPrinter Reader printing with quote and escape can emit CSV that its parser cannot read back.</action>
       <!-- ADD -->
       <action type="add" dev="ggregory" due-to="Gary Gregory, Indy, Sylvia van Os" issue="CSV-307">Add an "Android Compatibility" section to the web site.</action>
       <action type="add" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-325">Add CSVParser.Builder.setByteOffset(long) (#604).</action>

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2522,14 +2522,15 @@ public final class CSVFormat implements Serializable {
             return;
         }
         final char quote = getQuoteCharacter().charValue(); // Explicit unboxing is intentional
+        final char escape = isEscapeCharacterSet() ? getEscapeChar() : quote;
         // (1) Append opening quote
         append(quote, appendable);
-        // (2) Append Reader contents, doubling quotes
+        // (2) Append Reader contents, doubling quotes and escape characters
         int c;
         while (EOF != (c = reader.read())) {
             append((char) c, appendable);
-            if (c == quote) {
-                append(quote, appendable);
+            if (c == quote || c == escape) {
+                append((char) c, appendable);
             }
         }
         // (3) Append closing quote

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -966,6 +966,23 @@ class CSVFormatTest {
         assertEquals("\"\"\"a,b,c\r\nx,y,z\"", out.toString());
     }
 
+    /**
+     * Tests <a href="https://issues.apache.org/jira/browse/CSV-326">CSV-326</a>.
+     */
+    @Test
+    void testPrintWithQuotesEscapeBeforeQuote() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder()
+                .setEscape('\\')
+                .setQuote('"')
+                .get();
+        final String value = "\\\"";
+        final Appendable out = new StringBuilder();
+        format.print(new StringReader(value), out, true);
+        try (CSVParser parser = CSVParser.parse(out.toString(), format)) {
+            assertEquals(value, parser.getRecords().get(0).get(0));
+        }
+    }
+
     @Test
     void testQuoteCharSameAsCommentStartThrowsException() {
         assertThrows(IllegalArgumentException.class, () -> CSVFormat.DEFAULT.builder().setQuote('!').setCommentMarker('!').get());


### PR DESCRIPTION
Fixes CSV-326.

`CSVFormat#printWithQuotes(Reader, Appendable)` escaped embedded quote characters but did not escape a configured escape character. When a Reader value contained an escape character immediately before a quote, `CSVPrinter` could emit CSV that the same format could not parse back.

This updates the Reader quoted printing path to escape both quote and escape characters, matching the `CharSequence` printing path's round-trip behavior.

Added a regression test for Reader printing with an escape character before a quote.

Tests:
- `mvn -q test`