### PR TITLE
[CSV-327] Limit parser maxRows by produced records

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -51,6 +51,7 @@
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-322">CSVFormat.Builder.setQuote() does not refresh quotedNullString (#2447).</action>
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-324">Lexer.isDelimiter() accepts a partial multi-character delimiter at EOF (#603).</action>
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-325">CSVParser applies characterOffset to bytePosition (#604).</action>
+      <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-327">CSVParser applies maxRows to record numbers instead of rows produced when setRecordNumber(...) is used.</action>
       <!-- ADD -->
       <action type="add" dev="ggregory" due-to="Gary Gregory, Indy, Sylvia van Os" issue="CSV-307">Add an "Android Compatibility" section to the web site.</action>
       <action type="add" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-325">Add CSVParser.Builder.setByteOffset(long) (#604).</action>

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -237,6 +237,7 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
 
     final class CSVRecordIterator implements Iterator<CSVRecord> {
         private CSVRecord current;
+        private long recordCount;
 
         /**
          * Gets the next record or null at the end of stream or max rows read.
@@ -247,8 +248,11 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
          */
         private CSVRecord getNextRecord() {
             CSVRecord record = null;
-            if (format.useRow(recordNumber + 1)) {
+            if (format.useRow(recordCount + 1)) {
                 record = Uncheck.get(CSVParser.this::nextRecord);
+                if (record != null) {
+                    recordCount++;
+                }
             }
             return record;
         }

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -965,6 +965,23 @@ class CSVParserTest {
         }
     }
 
+    /**
+     * Tests <a href="https://issues.apache.org/jira/browse/CSV-327">CSV-327</a>.
+     */
+    @Test
+    void testGetRecordsMaxRowsWithRecordNumberOffset() throws IOException {
+        try (CSVParser parser = CSVParser.builder()
+                .setReader(new StringReader("a,b\nc,d\n"))
+                .setFormat(CSVFormat.DEFAULT.builder().setMaxRows(1).get())
+                .setRecordNumber(2)
+                .get()) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertEquals(2, records.get(0).getRecordNumber());
+            assertValuesEquals(new String[] { "a", "b" }, records.get(0));
+        }
+    }
+
     @Test
     void testGetRecordThreeBytesRead() throws Exception {
         final String code = "id,date,val5,val4\n" +


### PR DESCRIPTION
Fixes CSV-327.

`CSVParser` used the next assigned record number to decide whether `maxRows` allowed another row. When parsing resumes with `CSVParser.Builder#setRecordNumber(...)`, this can make a parser with `maxRows` return no records before it has produced any rows.

This changes the iterator to track how many records it has produced and applies `maxRows` to that count instead of the assigned record number.

Tests:
- `mvn -q test`