### PR TITLE
Clear escape delimiter buffer before peek in isEscapeDelimiter

### DIFF
--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -191,6 +191,7 @@ final class Lexer implements Closeable {
      * @throws IOException If an I/O error occurs.
      */
     boolean isEscapeDelimiter() throws IOException {
+        Arrays.fill(escapeDelimiterBuf, '\0');
         reader.peek(escapeDelimiterBuf);
         if (escapeDelimiterBuf[0] != delimiter[0]) {
             return false;

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1665,6 +1665,20 @@ class CSVParserTest {
         }
     }
 
+    /**
+     * A truncated escaped multi-character delimiter at EOF must stay literal data and not be completed from a stale
+     * escape delimiter look-ahead.
+     */
+    @Test
+    void testPartialEscapedMultiCharacterDelimiterAtEOF() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter("[|]").setEscape('!').get();
+        try (CSVParser parser = format.parse(new StringReader("x![!|!]y![!|"))) {
+            final CSVRecord record = parser.nextRecord();
+            assertEquals("x[|]y![!|", record.get(0));
+            assertEquals(1, record.size());
+        }
+    }
+
     @Test
     void testProvidedHeader() throws Exception {
         final Reader in = new StringReader("a,b,c\n1,2,3\nx,y,z");

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -421,6 +421,18 @@ class LexerTest {
         }
     }
 
+    /**
+     * A truncated escaped multi-character delimiter at EOF must not be accepted by reusing the previous escape delimiter
+     * look-ahead in {@link Lexer#isEscapeDelimiter()}.
+     */
+    @Test
+    void testPartialEscapedMultiCharacterDelimiterAtEOF() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter("[|]").setEscape('!').get();
+        try (Lexer lexer = createLexer("x![!|!]y![!|", format)) {
+            assertNextToken(EOF, "x[|]y![!|", lexer);
+        }
+    }
+
     @Test
     void testReadEscapeBackspace() throws IOException {
         try (Lexer lexer = createLexer("b", CSVFormat.DEFAULT.withEscape('\b'))) {


### PR DESCRIPTION
`isEscapeDelimiter()` peeks the next characters into the reused `escapeDelimiterBuf` look-ahead without clearing it first, so a truncated escaped multi-character delimiter at EOF is completed from the stale bytes of an earlier full escaped delimiter and the lexer appends a delimiter the input never contained. clearing the buffer before the peek mirrors the `delimiterBuf` reset added in `nextToken` for the plain multi-character delimiter path.

found while reading the partial-delimiter-at-EOF fix (CSV-324): the escaped-delimiter sibling was left unguarded.

for delimiter `[|]` and escape `!`, parsing `x![!|!]y![!|` returns `x[|]y[|]` before the change and the correct `x[|]y![!|` after. regression tests added in `LexerTest` and `CSVParserTest` (both fail without the one-line change).

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.