### PR TITLE
Escape quote char in printWithEscapes when QuoteMode is NONE

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2324,12 +2324,14 @@ public final class CSVFormat implements Serializable {
         final char[] delimArray = getDelimiterCharArray();
         final int delimLength = delimArray.length;
         final char escape = getEscapeChar();
+        final boolean quoteSet = isQuoteCharacterSet();
+        final char quote = quoteSet ? getQuoteCharacter().charValue() : 0;
         while (pos < end) {
             char c = charSeq.charAt(pos);
             final boolean isDelimiterStart = isDelimiter(c, charSeq, pos, delimArray, delimLength);
             final boolean isCr = c == Constants.CR;
             final boolean isLf = c == Constants.LF;
-            if (isCr || isLf || c == escape || isDelimiterStart) {
+            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart) {
                 // write out segment up until this char
                 if (pos > start) {
                     appendable.append(charSeq, start, pos);
@@ -2368,6 +2370,8 @@ public final class CSVFormat implements Serializable {
         final char[] delimArray = getDelimiterCharArray();
         final int delimLength = delimArray.length;
         final char escape = getEscapeChar();
+        final boolean quoteSet = isQuoteCharacterSet();
+        final char quote = quoteSet ? getQuoteCharacter().charValue() : 0;
         final StringBuilder builder = new StringBuilder(IOUtils.DEFAULT_BUFFER_SIZE);
         int c;
         final char[] lookAheadBuffer = new char[delimLength - 1];
@@ -2379,7 +2383,7 @@ public final class CSVFormat implements Serializable {
             final boolean isDelimiterStart = isDelimiter((char) c, test, pos, delimArray, delimLength);
             final boolean isCr = c == Constants.CR;
             final boolean isLf = c == Constants.LF;
-            if (isCr || isLf || c == escape || isDelimiterStart) {
+            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart) {
                 // write out segment up until this char
                 if (pos > start) {
                     append(builder.substring(start, pos), appendable);

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -424,6 +424,23 @@ class CSVPrinterTest {
     }
 
     @Test
+    void testQuoteCharEscapedWithQuoteModeNone() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setQuote('"').setEscape('?').setQuoteMode(QuoteMode.NONE).get();
+        final StringWriter sw = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            printer.printRecord("\"abc", "x\"y");
+        }
+        assertEquals("?\"abc,x?\"y\r\n", sw.toString());
+        // The emitted record must read back as the original values.
+        try (CSVParser parser = CSVParser.parse(sw.toString(), format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertEquals("\"abc", records.get(0).get(0));
+            assertEquals("x\"y", records.get(0).get(1));
+        }
+    }
+
+    @Test
     void testDelimiterEscaped() throws IOException {
         final StringWriter sw = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape('!').withQuote(null))) {

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -429,14 +429,17 @@ class CSVPrinterTest {
         final StringWriter sw = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(sw, format)) {
             printer.printRecord("\"abc", "x\"y");
+            printer.printRecord(new StringReader("\"abc"), new StringReader("x\"y"));
         }
-        assertEquals("?\"abc,x?\"y\r\n", sw.toString());
-        // The emitted record must read back as the original values.
+        assertEquals("?\"abc,x?\"y" + RECORD_SEPARATOR + "?\"abc,x?\"y" + RECORD_SEPARATOR, sw.toString());
+        // The emitted records must read back as the original values.
         try (CSVParser parser = CSVParser.parse(sw.toString(), format)) {
             final List<CSVRecord> records = parser.getRecords();
-            assertEquals(1, records.size());
-            assertEquals("\"abc", records.get(0).get(0));
-            assertEquals("x\"y", records.get(0).get(1));
+            assertEquals(2, records.size());
+            for (final CSVRecord record : records) {
+                assertEquals("\"abc", record.get(0));
+                assertEquals("x\"y", record.get(1));
+            }
         }
     }
 


### PR DESCRIPTION
With `QuoteMode.NONE` and both a quote and an escape character set, `CSVFormat.printWithEscapes` escapes the delimiter, `CR`, `LF` and the escape character, but never the quote character. A value that begins with the quote character is written verbatim, so `CSVPrinter` emits a record that its own `CSVParser` then rejects with `EOF reached before encapsulated token finished`. Found while round-tripping printed output back through the parser for the `quote('"').escape('?').QuoteMode.NONE` format already covered by `testPrintWithQuoteModeIsNONE`.

The quote character is still a token introducer on the parse side regardless of `QuoteMode`, so the printer has to escape it to stay readable. Adding it to the escape condition in both `printWithEscapes` overloads (`CharSequence` and `Reader`) keeps the fix next to where the delimiter and escape char are already handled, and is guarded so the escape-only path with no quote set is unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.