### PR TITLE
Quote value starting with comment marker in minimal quote mode

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2454,10 +2454,11 @@ public final class CSVFormat implements Serializable {
                 }
             } else {
                 char c = charSeq.charAt(pos);
-                if (c <= Constants.COMMENT) {
+                if (c <= Constants.COMMENT || isCommentMarkerSet() && c == commentMarker.charValue()) {
                     // Some other chars at the start of a value caused the parser to fail, so for now
                     // encapsulate if we start in anything less than '#'. We are being conservative
-                    // by including the default comment char too.
+                    // by including the default comment char and any configured comment marker too,
+                    // which the parser would otherwise read back as a comment line.
                     quote = true;
                 } else {
                     while (pos < len) {

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -1830,6 +1830,24 @@ class CSVPrinterTest {
     }
 
     @Test
+    void testQuoteCommentMarkerFirstChar() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setCommentMarker(';').get();
+        final StringWriter sw = new StringWriter();
+        final String col1 = ";comment-like";
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            printer.printRecord(col1, "b");
+        }
+        assertEquals("\";comment-like\",b" + RECORD_SEPARATOR, sw.toString());
+        // A value starting with the comment marker must read back as data, not a dropped comment line.
+        try (CSVParser parser = CSVParser.parse(sw.toString(), format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertEquals(col1, records.get(0).get(0));
+            assertEquals("b", records.get(0).get(1));
+        }
+    }
+
+    @Test
     void testQuoteNonNumeric() throws IOException {
         final StringWriter sw = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuoteMode(QuoteMode.NON_NUMERIC))) {

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -1835,15 +1835,24 @@ class CSVPrinterTest {
         final StringWriter sw = new StringWriter();
         final String col1 = ";comment-like";
         try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            // A real comment is written with the marker, unquoted.
+            printer.printComment("a real comment");
+            // A value starting with the marker is quoted, so it does not read back as a comment.
             printer.printRecord(col1, "b");
+            // The marker past the first character does not start a comment, so only the leading-marker value is quoted.
+            printer.printRecord("a;b", ";c");
         }
-        assertEquals("\";comment-like\",b" + RECORD_SEPARATOR, sw.toString());
-        // A value starting with the comment marker must read back as data, not a dropped comment line.
+        assertEquals("; a real comment" + RECORD_SEPARATOR +
+                "\";comment-like\",b" + RECORD_SEPARATOR +
+                "a;b,\";c\"" + RECORD_SEPARATOR, sw.toString());
+        // The comment is dropped on read; both data records survive intact.
         try (CSVParser parser = CSVParser.parse(sw.toString(), format)) {
             final List<CSVRecord> records = parser.getRecords();
-            assertEquals(1, records.size());
+            assertEquals(2, records.size());
             assertEquals(col1, records.get(0).get(0));
             assertEquals("b", records.get(0).get(1));
+            assertEquals("a;b", records.get(1).get(0));
+            assertEquals(";c", records.get(1).get(1));
         }
     }
 


### PR DESCRIPTION
`printWithQuotes` (the default `MINIMAL` quote mode) decides whether to encapsulate a value by special-casing only the hard-coded `#` (`Constants.COMMENT`) as the first character, so a configured comment marker greater than `#` such as `;` is left unquoted. I hit this round-tripping printer output back through the parser: `CSVFormat.DEFAULT.builder().setCommentMarker(';').get()` prints `";id", "name"` as `;id,name`, and re-parsing with that same format reads the line as a comment and silently drops the whole record.

The encapsulation check is the right place to fix it, since that is already where the printer protects the default comment char, the delimiter, the quote and newlines. The change quotes a value whenever its first character equals the configured comment marker, so the output reads back as data.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
