### PR TITLE
Clear delimiter buffer before each peek in isDelimiter

### DIFF
--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -153,6 +153,7 @@ final class Lexer implements Closeable {
             isLastTokenDelimiter = true;
             return true;
         }
+        Arrays.fill(delimiterBuf, '\0');
         reader.peek(delimiterBuf);
         for (int i = 0; i < delimiterBuf.length; i++) {
             if (delimiterBuf[i] != delimiter[i + 1]) {
@@ -274,7 +275,6 @@ final class Lexer implements Closeable {
             token.type = Token.Type.COMMENT;
             return token;
         }
-        Arrays.fill(delimiterBuf, '\0');
         // Important: make sure a new char gets consumed in each iteration
         while (token.type == Token.Type.INVALID) {
             // ignore whitespaces at beginning of a token

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1696,6 +1696,21 @@ class CSVParserTest {
         }
     }
 
+    /**
+     * A truncated multi-character delimiter at EOF must not be completed from the look-ahead buffer left dirty by an
+     * earlier non-matching peek in the same token.
+     */
+    @Test
+    void testPartialMultiCharacterDelimiterAtEOFAfterMismatch() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter("[|]").get();
+        // The "[a]" peek leaves ']' in the look-ahead buffer; the trailing "[|" must not match "[|]".
+        try (CSVParser parser = format.parse(new StringReader("x[a][|"))) {
+            final CSVRecord record = parser.nextRecord();
+            assertEquals("x[a][|", record.get(0));
+            assertEquals(1, record.size());
+        }
+    }
+
     @Test
     void testProvidedHeader() throws Exception {
         final Reader in = new StringReader("a,b,c\n1,2,3\nx,y,z");

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -433,6 +433,19 @@ class LexerTest {
         }
     }
 
+    /**
+     * A truncated multi-character delimiter at EOF must not be accepted by reusing the look-ahead buffer left dirty by an
+     * earlier non-matching peek in the same token (CSV-324 only cleared the buffer once per token).
+     */
+    @Test
+    void testPartialMultiCharacterDelimiterAtEOFAfterMismatch() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter("[|]").get();
+        // The "[a]" peek leaves ']' in the look-ahead buffer; the trailing "[|" must not match "[|]".
+        try (Lexer lexer = createLexer("x[a][|", format)) {
+            assertNextToken(EOF, "x[a][|", lexer);
+        }
+    }
+
     @Test
     void testReadEscapeBackspace() throws IOException {
         try (Lexer lexer = createLexer("b", CSVFormat.DEFAULT.withEscape('\b'))) {


### PR DESCRIPTION
`isDelimiter` peeks the next characters into the reused `delimiterBuf` look-ahead buffer without clearing it, so a non-matching peek earlier in the same token leaves stale chars in the trailing positions and a truncated multi-character delimiter at EOF false-matches. With delimiter `[|]`, input `x[a][|` is split into `x[a]` and an empty field, because the earlier `[a]` peek left `]` in the buffer and the trailing `[|` (only two of the three delimiter chars present before EOF) matches against that stale `]`. CSV-324 cleared `delimiterBuf` once per `nextToken`, but `isDelimiter` peeks repeatedly within a token, so the reset has to happen before the peek, the same way `isEscapeDelimiter` already does it; the once-per-token clear is then redundant and dropped.

Found while auditing the multi-character delimiter look-ahead after CSV-324.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
