### PR TITLE
[CSV-328] Fix quoted null string after disabling quote

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -53,6 +53,7 @@
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-325">CSVParser applies characterOffset to bytePosition (#604).</action>
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-326">CSVPrinter Reader printing with quote and escape can emit CSV that its parser cannot read back.</action>
       <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-327">CSVParser applies maxRows to record numbers instead of rows produced when setRecordNumber(...) is used.</action>
+      <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="CSV-328">CSVFormat.Builder.setNullString(String) can build an invalid quoted null string after setQuote(null).</action>
       <action type="fix" dev="ggregory" due-to="OldTruckDriver, Gary Gregory" issue="CSV-326">Escape Reader values with quote and escape (#606).</action>
       <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Clear escape delimiter buffer before peek in Lexer.isEscapeDelimiter() (#608, #611).</action>
       <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Escape quote char in printWithEscapes when QuoteMode is NONE (#609).</action>

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -780,8 +780,7 @@ public final class CSVFormat implements Serializable {
          */
         public Builder setNullString(final String nullString) {
             this.nullString = nullString;
-            this.quotedNullString = quoteCharacter + nullString + quoteCharacter;
-            return this;
+            return setQuotedNullString();
         }
 
         /**
@@ -806,6 +805,10 @@ public final class CSVFormat implements Serializable {
                 throw new IllegalArgumentException("The quoteCharacter cannot be a line break");
             }
             this.quoteCharacter = quoteCharacter;
+            return setQuotedNullString();
+        }
+
+        private Builder setQuotedNullString() {
             final Character quote = quoteCharacter != null ? quoteCharacter : Constants.DOUBLE_QUOTE_CHAR;
             this.quotedNullString = quote + nullString + quote;
             return this;

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -1040,6 +1040,11 @@ class CSVFormatTest {
         builder.setQuote((Character) null);
         builder.get().print(null, out, true);
         assertEquals("\"NULL\"", out.toString());
+        // reset, reverse setter order
+        out.setLength(0);
+        builder.setNullString(null).setQuote((Character) null).setNullString("NULL");
+        builder.get().print(null, out, true);
+        assertEquals("\"NULL\"", out.toString());
     }
 
     @Test


### PR DESCRIPTION
[CSV-328] Fix quoted null string after disabling quote

CSVFormat.Builder#setNullString(String) rebuilt quotedNullString by concatenating the nullable quoteCharacter field directly. When setQuote(null) was called before setNullString("NULL"), QuoteMode.ALL printed null as nullNULLnull instead of "NULL".

This change makes setNullString(String) and setQuote(Character) use the same quoted-null-string update logic, preserving the existing fallback to the default double quote when the quote character is disabled.

Tests cover both setter orders for setNullString("NULL") and setQuote(null).

Tests run:
- mvn -q -Dtest=org.apache.commons.csv.CSVFormatTest#testQuotedNullStringTracksQuoteCharacter test
- mvn -q -Dtest=org.apache.commons.csv.CSVFormatTest test
- mvn -q