### PR TITLE
Escape leading comment marker in printWithEscapes

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2329,12 +2329,16 @@ public final class CSVFormat implements Serializable {
         final char escape = getEscapeChar();
         final boolean quoteSet = isQuoteCharacterSet();
         final char quote = quoteSet ? getQuoteCharacter().charValue() : 0;
+        final boolean commentMarkerSet = isCommentMarkerSet();
+        final char commentChar = commentMarkerSet ? commentMarker.charValue() : 0; // Explicit unboxing is intentional
         while (pos < end) {
             char c = charSeq.charAt(pos);
             final boolean isDelimiterStart = isDelimiter(c, charSeq, pos, delimArray, delimLength);
             final boolean isCr = c == Constants.CR;
             final boolean isLf = c == Constants.LF;
-            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart) {
+            // A leading comment marker would be read back as a comment, so escape it.
+            final boolean isComment = commentMarkerSet && pos == 0 && c == commentChar;
+            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart || isComment) {
                 // write out segment up until this char
                 if (pos > start) {
                     appendable.append(charSeq, start, pos);
@@ -2375,8 +2379,11 @@ public final class CSVFormat implements Serializable {
         final char escape = getEscapeChar();
         final boolean quoteSet = isQuoteCharacterSet();
         final char quote = quoteSet ? getQuoteCharacter().charValue() : 0;
+        final boolean commentMarkerSet = isCommentMarkerSet();
+        final char commentChar = commentMarkerSet ? commentMarker.charValue() : 0; // Explicit unboxing is intentional
         final StringBuilder builder = new StringBuilder(IOUtils.DEFAULT_BUFFER_SIZE);
         int c;
+        boolean firstChar = true;
         final char[] lookAheadBuffer = new char[delimLength - 1];
         while (EOF != (c = bufferedReader.read())) {
             builder.append((char) c);
@@ -2386,7 +2393,10 @@ public final class CSVFormat implements Serializable {
             final boolean isDelimiterStart = isDelimiter((char) c, test, pos, delimArray, delimLength);
             final boolean isCr = c == Constants.CR;
             final boolean isLf = c == Constants.LF;
-            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart) {
+            // A leading comment marker would be read back as a comment, so escape it.
+            final boolean isComment = commentMarkerSet && firstChar && c == commentChar;
+            firstChar = false;
+            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart || isComment) {
                 // write out segment up until this char
                 if (pos > start) {
                     append(builder.substring(start, pos), appendable);

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -570,6 +570,57 @@ class CSVPrinterTest {
     }
 
     @Test
+    void testEscapeCommentMarkerFirstChar() throws IOException {
+        // No quoting available in escape mode, so a leading comment marker must be escaped or the
+        // record reads back as a comment and is dropped. Mirrors the quoting fix for QuoteMode.MINIMAL.
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setQuote(null).setEscape('\\').setCommentMarker(';').get();
+        final StringWriter sw = new StringWriter();
+        final String col1 = ";comment-like";
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            printer.printRecord(col1, "b");
+            printer.printRecord(new StringReader(col1), new StringReader("b"));
+            // The marker past the first character does not start a comment and is left alone.
+            printer.printRecord("a;b", ";c");
+        }
+        final String string = sw.toString();
+        assertEquals("\\;comment-like,b" + RECORD_SEPARATOR +
+                "\\;comment-like,b" + RECORD_SEPARATOR +
+                "a;b,\\;c" + RECORD_SEPARATOR, string);
+        // The emitted records must read back as the original values, none parsed as a comment.
+        try (CSVParser parser = CSVParser.parse(string, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(3, records.size());
+            assertEquals(col1, records.get(0).get(0));
+            assertEquals("b", records.get(0).get(1));
+            assertEquals(col1, records.get(1).get(0));
+            assertEquals("b", records.get(1).get(1));
+            assertEquals("a;b", records.get(2).get(0));
+            assertEquals(";c", records.get(2).get(1));
+        }
+    }
+
+    @Test
+    void testEscapeCommentMarkerFirstCharWithQuoteModeNone() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setEscape('\\').setQuoteMode(QuoteMode.NONE).setCommentMarker(';').get();
+        final StringWriter sw = new StringWriter();
+        final String col1 = ";bar";
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            printer.printRecord(col1, "b");
+            printer.printRecord(new StringReader(col1), new StringReader("b"));
+        }
+        final String string = sw.toString();
+        assertEquals("\\;bar,b" + RECORD_SEPARATOR + "\\;bar,b" + RECORD_SEPARATOR, string);
+        try (CSVParser parser = CSVParser.parse(string, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(2, records.size());
+            for (final CSVRecord record : records) {
+                assertEquals(col1, record.get(0));
+                assertEquals("b", record.get(1));
+            }
+        }
+    }
+
+    @Test
     void testEscapeNull1() throws IOException {
         final StringWriter sw = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withEscape(null))) {


### PR DESCRIPTION
With an escape character set and no quote character (or `QuoteMode.NONE`), `CSVFormat.printWithEscapes` escapes the delimiter, `CR`, `LF`, the escape character and (since #609) the quote character, but never a comment marker. A value whose first character is the configured comment marker is written verbatim, so `CSVPrinter` emits a record that its own `CSVParser` reads back as a comment and silently drops. `CSVFormat.DEFAULT.builder().setQuote(null).setEscape('\').setCommentMarker(';').get()` prints `;foo` for the value `;foo`, and re-parsing that output yields zero records. Found round-tripping printer output back through the parser.

The escape condition is the right place to fix it, next to where the delimiter, escape char and quote char are already handled. The change escapes the comment marker when it is the first character of the value, in both `printWithEscapes` overloads (`CharSequence` and `Reader`). This is the escape-mode counterpart to #610, which protected the comment marker only in the `MINIMAL` quoting path and left the escape paths out.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
