### PR TITLE
Skip byte counting at EOF in ExtendedBufferedReader.read

### DIFF
--- a/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
+++ b/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
@@ -210,7 +210,7 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
         if (current == CR || current == LF && lastChar != CR || current == EOF && lastChar != CR && lastChar != LF && lastChar != EOF) {
             lineNumber++;
         }
-        if (encoder != null) {
+        if (encoder != null && current != EOF) {
             this.bytesRead += getEncodedCharLength(current);
         }
         lastChar = current;

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -692,6 +692,27 @@ class CSVParserTest {
     }
 
     @Test
+    void testGetBytePositionWithSingleByteCharset() throws IOException {
+        // A single-byte charset cannot encode U+FFFF, the char value of the EOF sentinel.
+        // Byte counting must skip the EOF read so a valid file parses without throwing.
+        final String code = "a,b\nc,d\n";
+        try (CSVParser parser = CSVParser.builder()
+                .setReader(new StringReader(code))
+                .setFormat(CSVFormat.DEFAULT)
+                .setCharset(StandardCharsets.ISO_8859_1)
+                .setTrackBytes(true)
+                .get()) {
+            final CSVRecord first = parser.nextRecord();
+            final CSVRecord second = parser.nextRecord();
+            assertNotNull(first);
+            assertNotNull(second);
+            assertNull(parser.nextRecord());
+            assertEquals(0, first.getBytePosition());
+            assertEquals(4, second.getBytePosition());
+        }
+    }
+
+    @Test
     void testGetBytePositionWithCharacterOffsetAndMultiBytePrefix() throws Exception {
         final String row0 = "é,x\n";
         final Charset charset = UTF_8;


### PR DESCRIPTION
`ExtendedBufferedReader.read()` feeds the `EOF` sentinel (`-1`) to `getEncodedCharLength` when `trackBytes` is on, narrowing it to `(char) -1` (`U+FFFF`) and pushing it through the charset encoder. A single-byte charset like `ISO-8859-1` or `US-ASCII` cannot encode `U+FFFF`, so byte tracking throws `UnmappableCharacterException` at end of input on an otherwise valid file; with `UTF-8`/`UTF-16` it silently adds a few phantom bytes to the count. Found while running `getBytePosition` with a non-UTF charset; the `read(char[], off, len)` overload already guards this with `len > 0`, so this mirrors that guard for the single-char path.