### PR TITLE
Keep quoted empty trailing field with trailingDelimiter

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -883,6 +883,16 @@ public final class CSVFormat implements Serializable {
         /**
          * Sets whether to add a trailing delimiter.
          *
+         * <p>
+         * When writing, a delimiter is appended after the last value of each record. When reading, the empty field
+         * that such a trailing delimiter produces is dropped so the output round-trips back to the original record;
+         * a quoted empty trailing field ({@code ""}) is a real value rather than a trailing delimiter and is kept.
+         * </p>
+         * <p>
+         * This is unrelated to {@link #setTrailingData(boolean) trailing data}, which controls whether characters
+         * after the closing quote of an encapsulated value are tolerated when reading.
+         * </p>
+         *
          * @param trailingDelimiter whether to add a trailing delimiter.
          * @return This instance.
          */
@@ -2011,6 +2021,16 @@ public final class CSVFormat implements Serializable {
 
     /**
      * Gets whether to add a trailing delimiter.
+     *
+     * <p>
+     * When writing, a delimiter is appended after the last value of each record. When reading, the empty field
+     * that such a trailing delimiter produces is dropped so the output round-trips back to the original record;
+     * a quoted empty trailing field ({@code ""}) is a real value rather than a trailing delimiter and is kept.
+     * </p>
+     * <p>
+     * This is unrelated to {@link #getTrailingData() trailing data}, which controls whether characters after the
+     * closing quote of an encapsulated value are tolerated when reading.
+     * </p>
      *
      * @return whether to add a trailing delimiter.
      * @since 1.3

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -580,7 +580,9 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
 
     private void addRecordValue(final boolean lastRecord) {
         final String input = format.trim(reusableToken.content.toString());
-        if (lastRecord && input.isEmpty() && format.getTrailingDelimiter()) {
+        // Only drop the empty field produced by an actual trailing delimiter. A quoted empty
+        // field ("") is a real value, not a trailing delimiter, so it must be kept.
+        if (lastRecord && input.isEmpty() && format.getTrailingDelimiter() && !reusableToken.isQuoted) {
             return;
         }
         recordList.add(handleNull(input));

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1950,6 +1950,23 @@ class CSVParserTest {
     }
 
     @Test
+    void testTrailingDelimiterKeepsQuotedEmptyLastField() throws Exception {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setTrailingDelimiter(true).get();
+        try (CSVParser parser = CSVParser.parse("a,b,\"\"", format)) {
+            final CSVRecord record = parser.iterator().next();
+            assertEquals(3, record.size());
+            assertEquals("a", record.get(0));
+            assertEquals("b", record.get(1));
+            assertEquals("", record.get(2));
+        }
+        // An unquoted trailing delimiter still drops the empty field.
+        try (CSVParser parser = CSVParser.parse("a,b,", format)) {
+            final CSVRecord record = parser.iterator().next();
+            assertEquals(2, record.size());
+        }
+    }
+
+    @Test
     void testTrim() throws Exception {
         final Reader in = new StringReader("a,a,a\n\" 1 \",\" 2 \",\" 3 \"\nx,y,z");
         try (CSVParser parser = CSVFormat.DEFAULT.withHeader("X", "Y", "Z").withSkipHeaderRecord().withTrim().parse(in)) {


### PR DESCRIPTION
`addRecordValue` drops the empty last field whenever the format's `trailingDelimiter` is enabled, checking only that the trimmed value is empty. A quoted empty field at the end of a record is a real value, not a trailing delimiter, so `a,b,""` parsed with `setTrailingDelimiter(true)` came back as two values `[a, b]` instead of three `[a, b, ""]`. The unquoted case `a,b,` is a genuine trailing delimiter and still collapses to two fields. Fixed by only dropping the field when the token is unquoted; `reusableToken.isQuoted` is already tracked and used by `handleNull`.

Found while round-tripping records that contain an explicit empty quoted field.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
