### PR TITLE
Refactor Commons CSV maintainability hotspots

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -1655,19 +1655,31 @@ public final class CSVFormat implements Serializable {
     }
 
     private void append(final char c, final Appendable appendable) throws IOException {
-        // try {
         appendable.append(c);
-        // } catch (final IOException e) {
-        // throw new UncheckedIOException(e);
-        // }
     }
 
     private void append(final CharSequence csq, final Appendable appendable) throws IOException {
-        // try {
         appendable.append(csq);
-        // } catch (final IOException e) {
-        // throw new UncheckedIOException(e);
-        // }
+    }
+
+    private void appendArrayOption(final StringBuilder sb, final boolean condition, final String name, final String[] values) {
+        if (condition) {
+            sb.append(Constants.SP);
+            sb.append(name).append(':').append(Arrays.toString(values));
+        }
+    }
+
+    private void appendDelimiterIfNeeded(final Appendable out, final boolean newRecord) throws IOException {
+        if (!newRecord) {
+            append(getDelimiterString(), out);
+        }
+    }
+
+    private void appendOption(final StringBuilder sb, final boolean condition, final String name, final Object value) {
+        if (condition) {
+            sb.append(Constants.SP);
+            sb.append(name).append("=<").append(value).append('>');
+        }
     }
 
     /**
@@ -1715,6 +1727,13 @@ public final class CSVFormat implements Serializable {
     private void escape(final char c, final Appendable appendable) throws IOException {
         append(escapeCharacter.charValue(), appendable); // Explicit unboxing is intentional
         append(c, appendable);
+    }
+
+    private int escapeLineBreak(final int c) {
+        if (c == Constants.LF) {
+            return 'n';
+        }
+        return c == Constants.CR ? 'r' : c;
     }
 
     /**
@@ -2179,9 +2198,7 @@ public final class CSVFormat implements Serializable {
     private void print(final InputStream inputStream, final Appendable out, final boolean newRecord) throws IOException {
         // InputStream is never null here
         // There is nothing to escape when quoting is used which is the default.
-        if (!newRecord) {
-            append(getDelimiterString(), out);
-        }
+        appendDelimiterIfNeeded(out, newRecord);
         final boolean quoteCharacterSet = isQuoteCharacterSet();
         if (quoteCharacterSet) {
             append(getQuoteCharacter().charValue(), out); // Explicit unboxing is intentional
@@ -2207,39 +2224,22 @@ public final class CSVFormat implements Serializable {
      * @since 1.4
      */
     public synchronized void print(final Object value, final Appendable out, final boolean newRecord) throws IOException {
-        // null values are considered empty
-        // Only call CharSequence.toString() if you have to, helps GC-free use cases.
-        CharSequence charSequence;
-        if (value == null) {
-            // https://issues.apache.org/jira/browse/CSV-203
-            if (null == nullString) {
-                charSequence = Constants.EMPTY;
-            } else if (QuoteMode.ALL == quoteMode) {
-                charSequence = quotedNullString;
-            } else {
-                charSequence = nullString;
-            }
-        } else if (value instanceof CharSequence) {
-            charSequence = (CharSequence) value;
-        } else if (value instanceof Reader) {
+        if (value instanceof Reader) {
             print((Reader) value, out, newRecord);
             return;
-        } else if (value instanceof InputStream) {
+        }
+        if (value instanceof InputStream) {
             print((InputStream) value, out, newRecord);
             return;
-        } else {
-            charSequence = value.toString();
         }
-        charSequence = getTrim() ? trim(charSequence) : charSequence;
+        final CharSequence charSequence = getTrim() ? trim(toCharSequence(value)) : toCharSequence(value);
         print(value, charSequence, out, newRecord);
     }
 
     private synchronized void print(final Object object, final CharSequence value, final Appendable out, final boolean newRecord) throws IOException {
         final int offset = 0;
         final int len = value.length();
-        if (!newRecord) {
-            out.append(getDelimiterString());
-        }
+        appendDelimiterIfNeeded(out, newRecord);
         if (object == null) {
             out.append(value);
         } else if (isQuoteCharacterSet()) {
@@ -2272,9 +2272,7 @@ public final class CSVFormat implements Serializable {
 
     private void print(final Reader reader, final Appendable out, final boolean newRecord) throws IOException {
         // Reader is never null here
-        if (!newRecord) {
-            append(getDelimiterString(), out);
-        }
+        appendDelimiterIfNeeded(out, newRecord);
         if (isQuoteCharacterSet()) {
             printWithQuotes(reader, out);
         } else if (isEscapeCharacterSet()) {
@@ -2337,6 +2335,11 @@ public final class CSVFormat implements Serializable {
         println(appendable);
     }
 
+    private boolean isEscapeRequired(final int c, final char escape, final boolean quoteSet, final char quote, final boolean delimiterStart,
+            final boolean commentStart) {
+        return c == Constants.CR || c == Constants.LF || c == escape || quoteSet && c == quote || delimiterStart || commentStart;
+    }
+
     /*
      * This method must only be called if escaping is enabled, otherwise can throw exceptions.
      */
@@ -2354,21 +2357,14 @@ public final class CSVFormat implements Serializable {
         while (pos < end) {
             char c = charSeq.charAt(pos);
             final boolean isDelimiterStart = isDelimiter(c, charSeq, pos, delimArray, delimLength);
-            final boolean isCr = c == Constants.CR;
-            final boolean isLf = c == Constants.LF;
             // A leading comment marker would be read back as a comment, so escape it.
             final boolean isComment = commentMarkerSet && pos == 0 && c == commentChar;
-            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart || isComment) {
+            if (isEscapeRequired(c, escape, quoteSet, quote, isDelimiterStart, isComment)) {
                 // write out segment up until this char
                 if (pos > start) {
                     appendable.append(charSeq, start, pos);
                 }
-                if (isLf) {
-                    c = 'n';
-                } else if (isCr) {
-                    c = 'r';
-                }
-                escape(c, appendable);
+                escape((char) escapeLineBreak(c), appendable);
                 if (isDelimiterStart) {
                     for (int i = 1; i < delimLength; i++) {
                         pos++;
@@ -2411,24 +2407,17 @@ public final class CSVFormat implements Serializable {
             bufferedReader.peek(lookAheadBuffer);
             final String test = builder.toString() + new String(lookAheadBuffer);
             final boolean isDelimiterStart = isDelimiter((char) c, test, pos, delimArray, delimLength);
-            final boolean isCr = c == Constants.CR;
-            final boolean isLf = c == Constants.LF;
             // A leading comment marker would be read back as a comment, so escape it.
             final boolean isComment = commentMarkerSet && firstChar && c == commentChar;
             firstChar = false;
-            if (isCr || isLf || c == escape || quoteSet && c == quote || isDelimiterStart || isComment) {
+            if (isEscapeRequired(c, escape, quoteSet, quote, isDelimiterStart, isComment)) {
                 // write out segment up until this char
                 if (pos > start) {
                     append(builder.substring(start, pos), appendable);
                     builder.setLength(0);
                     pos = -1;
                 }
-                if (isLf) {
-                    c = 'n';
-                } else if (isCr) {
-                    c = 'r';
-                }
-                escape((char) c, appendable);
+                escape((char) escapeLineBreak(c), appendable);
                 if (isDelimiterStart) {
                     for (int i = 1; i < delimLength; i++) {
                         escape((char) bufferedReader.read(), appendable);
@@ -2449,102 +2438,76 @@ public final class CSVFormat implements Serializable {
      * The original object is needed so can check for Number
      */
     private void printWithQuotes(final Object object, final CharSequence charSeq, final Appendable out, final boolean newRecord) throws IOException {
-        boolean quote = false;
-        int start = 0;
-        int pos = 0;
-        final int len = charSeq.length();
-        final char[] delim = getDelimiterCharArray();
-        final int delimLength = delim.length;
         final char quoteChar = getQuoteCharacter().charValue(); // Explicit unboxing is intentional
         // If escape char not specified, default to the quote char
         // This avoids having to keep checking whether there is an escape character
         // at the cost of checking against quote twice
         final char escapeChar = isEscapeCharacterSet() ? getEscapeChar() : quoteChar;
-        QuoteMode quoteModePolicy = getQuoteMode();
-        if (quoteModePolicy == null) {
-            quoteModePolicy = QuoteMode.MINIMAL;
-        }
-        switch (quoteModePolicy) {
-        case ALL:
-        case ALL_NON_NULL:
-            quote = true;
-            break;
-        case NON_NUMERIC:
-            quote = !(object instanceof Number);
-            break;
-        case NONE:
-            // Use the existing escaping code
+        if (getQuoteMode() == QuoteMode.NONE) {
             printWithEscapes(charSeq, out);
             return;
-        case MINIMAL:
-            if (len <= 0) {
-                // Always quote an empty token that is the first
-                // on the line, as it may be the only thing on the
-                // line. If it were not quoted in that case,
-                // an empty line has no tokens.
-                if (newRecord) {
-                    quote = true;
-                }
-            } else {
-                char c = charSeq.charAt(pos);
-                if (c <= Constants.COMMENT || isCommentMarkerSet() && c == commentMarker.charValue()) {
-                    // Some other chars at the start of a value caused the parser to fail, so for now
-                    // encapsulate if we start in anything less than '#'. We are being conservative
-                    // by including the default comment char and any configured comment marker too,
-                    // which the parser would otherwise read back as a comment line.
-                    quote = true;
-                } else {
-                    while (pos < len) {
-                        c = charSeq.charAt(pos);
-                        if (c == Constants.LF || c == Constants.CR || c == quoteChar || c == escapeChar || isDelimiter(c, charSeq, pos, delim, delimLength)) {
-                            quote = true;
-                            break;
-                        }
-                        pos++;
-                    }
-
-                    if (!quote) {
-                        pos = len - 1;
-                        c = charSeq.charAt(pos);
-                        // Some other chars at the end caused the parser to fail, so for now
-                        // encapsulate if we end in anything less than ' '
-                        if (isTrimChar(c)) {
-                            quote = true;
-                        }
-                    }
-                }
-            }
-            if (!quote) {
-                // No encapsulation needed - write out the original value
-                out.append(charSeq, start, len);
-                return;
-            }
-            break;
-        default:
-            throw new IllegalStateException("Unexpected Quote value: " + quoteModePolicy);
         }
-        if (!quote) {
+        if (!shouldQuote(object, charSeq, newRecord, quoteChar, escapeChar)) {
             // No encapsulation needed - write out the original value
-            out.append(charSeq, start, len);
+            out.append(charSeq, 0, charSeq.length());
             return;
         }
-        // We hit something that needed encapsulation
+        printQuotedValue(charSeq, out, quoteChar, escapeChar);
+    }
+
+    private void printQuotedValue(final CharSequence charSeq, final Appendable out, final char quoteChar, final char escapeChar) throws IOException {
+        int start = 0;
+        int pos = 0;
+        final int len = charSeq.length();
         out.append(quoteChar);
-        // Pick up where we left off: pos should be positioned on the first character that caused
-        // the need for encapsulation.
         while (pos < len) {
             final char c = charSeq.charAt(pos);
             if (c == quoteChar || c == escapeChar) {
-                // write out the chunk up until this point
                 out.append(charSeq, start, pos);
-                out.append(escapeChar); // now output the escape
-                start = pos; // and restart with the matched char
+                out.append(escapeChar);
+                start = pos;
             }
             pos++;
         }
-        // Write the last segment
         out.append(charSeq, start, pos);
         out.append(quoteChar);
+    }
+
+    private boolean shouldQuote(final Object object, final CharSequence charSeq, final boolean newRecord, final char quoteChar, final char escapeChar) {
+        final QuoteMode quoteModePolicy = quoteMode != null ? quoteMode : QuoteMode.MINIMAL;
+        switch (quoteModePolicy) {
+        case ALL:
+        case ALL_NON_NULL:
+            return true;
+        case NON_NUMERIC:
+            return !(object instanceof Number);
+        case MINIMAL:
+            return shouldQuoteMinimal(charSeq, newRecord, quoteChar, escapeChar);
+        case NONE:
+            return false;
+        default:
+            throw new IllegalStateException("Unexpected Quote value: " + quoteModePolicy);
+        }
+    }
+
+    private boolean shouldQuoteMinimal(final CharSequence charSeq, final boolean newRecord, final char quoteChar, final char escapeChar) {
+        final int len = charSeq.length();
+        if (len <= 0) {
+            return newRecord;
+        }
+        final char first = charSeq.charAt(0);
+        if (first <= Constants.COMMENT || isCommentMarkerSet() && first == commentMarker.charValue()) {
+            return true;
+        }
+        final char[] delim = getDelimiterCharArray();
+        final int delimLength = delim.length;
+        for (int pos = 0; pos < len; pos++) {
+            final char c = charSeq.charAt(pos);
+            if (c == Constants.LF || c == Constants.CR || c == quoteChar || c == escapeChar || isDelimiter(c, charSeq, pos, delim, delimLength)) {
+                return true;
+            }
+        }
+        return isTrimChar(charSeq.charAt(len - 1));
     }
 
     /**
@@ -2579,30 +2542,12 @@ public final class CSVFormat implements Serializable {
     public String toString() {
         final StringBuilder sb = new StringBuilder();
         sb.append("Delimiter=<").append(delimiter).append('>');
-        if (isEscapeCharacterSet()) {
-            sb.append(Constants.SP);
-            sb.append("Escape=<").append(escapeCharacter).append('>');
-        }
-        if (isQuoteCharacterSet()) {
-            sb.append(Constants.SP);
-            sb.append("QuoteChar=<").append(quoteCharacter).append('>');
-        }
-        if (quoteMode != null) {
-            sb.append(Constants.SP);
-            sb.append("QuoteMode=<").append(quoteMode).append('>');
-        }
-        if (isCommentMarkerSet()) {
-            sb.append(Constants.SP);
-            sb.append("CommentStart=<").append(commentMarker).append('>');
-        }
-        if (isNullStringSet()) {
-            sb.append(Constants.SP);
-            sb.append("NullString=<").append(nullString).append('>');
-        }
-        if (recordSeparator != null) {
-            sb.append(Constants.SP);
-            sb.append("RecordSeparator=<").append(recordSeparator).append('>');
-        }
+        appendOption(sb, isEscapeCharacterSet(), "Escape", escapeCharacter);
+        appendOption(sb, isQuoteCharacterSet(), "QuoteChar", quoteCharacter);
+        appendOption(sb, quoteMode != null, "QuoteMode", quoteMode);
+        appendOption(sb, isCommentMarkerSet(), "CommentStart", commentMarker);
+        appendOption(sb, isNullStringSet(), "NullString", nullString);
+        appendOption(sb, recordSeparator != null, "RecordSeparator", recordSeparator);
         if (getIgnoreEmptyLines()) {
             sb.append(" EmptyLines:ignored");
         }
@@ -2613,19 +2558,26 @@ public final class CSVFormat implements Serializable {
             sb.append(" IgnoreHeaderCase:ignored");
         }
         sb.append(" SkipHeaderRecord:").append(skipHeaderRecord);
-        if (headerComments != null) {
-            sb.append(Constants.SP);
-            sb.append("HeaderComments:").append(Arrays.toString(headerComments));
-        }
-        if (headers != null) {
-            sb.append(Constants.SP);
-            sb.append("Header:").append(Arrays.toString(headers));
-        }
+        appendArrayOption(sb, headerComments != null, "HeaderComments", headerComments);
+        appendArrayOption(sb, headers != null, "Header", headers);
         return sb.toString();
     }
 
     String trim(final String value) {
         return getTrim() ? value.trim() : value;
+    }
+
+    private CharSequence toCharSequence(final Object value) {
+        // null values are considered empty
+        // Only call CharSequence.toString() if you have to, helps GC-free use cases.
+        if (value == null) {
+            // https://issues.apache.org/jira/browse/CSV-203
+            if (null == nullString) {
+                return Constants.EMPTY;
+            }
+            return QuoteMode.ALL == quoteMode ? quotedNullString : nullString;
+        }
+        return value instanceof CharSequence ? (CharSequence) value : value.toString();
     }
 
     boolean useMaxRows() {
@@ -2646,25 +2598,16 @@ public final class CSVFormat implements Serializable {
      * @throws IllegalArgumentException Throw when any attribute is invalid or inconsistent with other attributes.
      */
     private void validate() throws IllegalArgumentException {
-        if (quoteCharacter != null && contains(delimiter, quoteCharacter.charValue())) { // Explicit unboxing is intentional
-            throw new IllegalArgumentException("The quoteChar character and the delimiter cannot be the same ('" + quoteCharacter + "')");
-        }
-        if (escapeCharacter != null && contains(delimiter, escapeCharacter.charValue())) { // Explicit unboxing is intentional
-            throw new IllegalArgumentException("The escape character and the delimiter cannot be the same ('" + escapeCharacter + "')");
-        }
-        if (commentMarker != null && contains(delimiter, commentMarker.charValue())) { // Explicit unboxing is intentional
-            throw new IllegalArgumentException("The comment start character and the delimiter cannot be the same ('" + commentMarker + "')");
-        }
-        if (quoteCharacter != null && quoteCharacter.equals(commentMarker)) {
-            throw new IllegalArgumentException("The comment start character and the quoteChar cannot be the same ('" + commentMarker + "')");
-        }
-        if (escapeCharacter != null && escapeCharacter.equals(commentMarker)) {
-            throw new IllegalArgumentException("The comment start and the escape character cannot be the same ('" + commentMarker + "')");
-        }
-        if (escapeCharacter == null && quoteMode == QuoteMode.NONE) {
-            throw new IllegalArgumentException("Quote mode set to NONE but no escape character is set");
-        }
-        // Validate headers
+        validateDelimiterCharacter(quoteCharacter, "The quoteChar character and the delimiter cannot be the same ('%s')");
+        validateDelimiterCharacter(escapeCharacter, "The escape character and the delimiter cannot be the same ('%s')");
+        validateDelimiterCharacter(commentMarker, "The comment start character and the delimiter cannot be the same ('%s')");
+        validateCharacterPair(quoteCharacter, commentMarker, "The comment start character and the quoteChar cannot be the same ('%s')");
+        validateCharacterPair(escapeCharacter, commentMarker, "The comment start and the escape character cannot be the same ('%s')");
+        validateQuoteMode();
+        validateHeaders();
+    }
+
+    private void validateHeaders() {
         if (headers != null && duplicateHeaderMode != DuplicateHeaderMode.ALLOW_ALL) {
             final Set<String> dupCheckSet = new HashSet<>(headers.length);
             final boolean emptyDuplicatesAllowed = duplicateHeaderMode == DuplicateHeaderMode.ALLOW_EMPTY;
@@ -2678,6 +2621,24 @@ public final class CSVFormat implements Serializable {
                             Arrays.toString(headers)));
                 }
             }
+        }
+    }
+
+    private void validateCharacterPair(final Character left, final Character right, final String message) {
+        if (left != null && left.equals(right)) {
+            throw new IllegalArgumentException(String.format(message, right));
+        }
+    }
+
+    private void validateDelimiterCharacter(final Character character, final String message) {
+        if (character != null && contains(delimiter, character.charValue())) { // Explicit unboxing is intentional
+            throw new IllegalArgumentException(String.format(message, character));
+        }
+    }
+
+    private void validateQuoteMode() {
+        if (escapeCharacter == null && quoteMode == QuoteMode.NONE) {
+            throw new IllegalArgumentException("Quote mode set to NONE but no escape character is set");
         }
     }
 

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -618,55 +618,76 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         final String[] formatHeader = format.getHeader();
         if (formatHeader != null) {
             headerMap = createEmptyHeaderMap();
-            String[] headerRecord = null;
-            if (formatHeader.length == 0) {
-                // read the header from the first line of the file
-                final CSVRecord nextRecord = nextRecord();
-                if (nextRecord != null) {
-                    headerRecord = nextRecord.values();
-                    headerComment = nextRecord.getComment();
-                }
-            } else {
-                if (format.getSkipHeaderRecord()) {
-                    final CSVRecord nextRecord = nextRecord();
-                    if (nextRecord != null) {
-                        headerComment = nextRecord.getComment();
-                    }
-                }
-                headerRecord = formatHeader;
-            }
-            // build the name to index mappings
-            if (headerRecord != null) {
-                // Track an occurrence of a null, empty or blank header.
-                boolean observedMissing = false;
-                for (int i = 0; i < headerRecord.length; i++) {
-                    final String header = headerRecord[i];
-                    final boolean blankHeader = CSVFormat.isBlank(header);
-                    if (blankHeader && !format.getAllowMissingColumnNames()) {
-                        throw new IllegalArgumentException("A header name is missing in " + Arrays.toString(headerRecord));
-                    }
-                    final boolean containsHeader = blankHeader ? observedMissing : headerMap.containsKey(header);
-                    final DuplicateHeaderMode headerMode = format.getDuplicateHeaderMode();
-                    final boolean duplicatesAllowed = headerMode == DuplicateHeaderMode.ALLOW_ALL;
-                    final boolean emptyDuplicatesAllowed = headerMode == DuplicateHeaderMode.ALLOW_EMPTY;
-                    if (containsHeader && !duplicatesAllowed && !(blankHeader && emptyDuplicatesAllowed)) {
-                        throw new IllegalArgumentException(String.format(
-                                "The header contains a duplicate name: \"%s\" in %s. If this is valid then use CSVFormat.Builder.setDuplicateHeaderMode().",
-                                header, Arrays.toString(headerRecord)));
-                    }
-                    observedMissing |= blankHeader;
-                    if (header != null) {
-                        headerMap.put(header, Integer.valueOf(i)); // Explicit boxing is intentional
-                        if (headerNames == null) {
-                            headerNames = new ArrayList<>(headerRecord.length);
-                        }
-                        headerNames.add(header);
-                    }
-                }
-            }
+            final String[] headerRecord = resolveHeaderRecord(formatHeader);
+            headerNames = buildHeaderNames(headerMap, headerRecord);
         }
         // Make header names Collection immutable
         return new Headers(headerMap, headerNames == null ? Collections.emptyList() : Collections.unmodifiableList(headerNames));
+    }
+
+    private String[] resolveHeaderRecord(final String[] formatHeader) throws IOException {
+        if (formatHeader.length == 0) {
+            return readHeaderRecord();
+        }
+        if (format.getSkipHeaderRecord()) {
+            skipHeaderRecord();
+        }
+        return formatHeader;
+    }
+
+    private String[] readHeaderRecord() throws IOException {
+        // read the header from the first line of the file
+        final CSVRecord nextRecord = nextRecord();
+        if (nextRecord == null) {
+            return null;
+        }
+        headerComment = nextRecord.getComment();
+        return nextRecord.values();
+    }
+
+    private void skipHeaderRecord() throws IOException {
+        final CSVRecord nextRecord = nextRecord();
+        if (nextRecord != null) {
+            headerComment = nextRecord.getComment();
+        }
+    }
+
+    private List<String> buildHeaderNames(final Map<String, Integer> headerMap, final String[] headerRecord) {
+        if (headerRecord == null) {
+            return null;
+        }
+        List<String> headerNames = null;
+        boolean observedMissing = false;
+        for (int i = 0; i < headerRecord.length; i++) {
+            final String header = headerRecord[i];
+            final boolean blankHeader = CSVFormat.isBlank(header);
+            validateHeader(headerRecord, header, blankHeader, observedMissing, headerMap);
+            observedMissing |= blankHeader;
+            if (header != null) {
+                headerMap.put(header, Integer.valueOf(i)); // Explicit boxing is intentional
+                if (headerNames == null) {
+                    headerNames = new ArrayList<>(headerRecord.length);
+                }
+                headerNames.add(header);
+            }
+        }
+        return headerNames;
+    }
+
+    private void validateHeader(final String[] headerRecord, final String header, final boolean blankHeader, final boolean observedMissing,
+            final Map<String, Integer> headerMap) {
+        if (blankHeader && !format.getAllowMissingColumnNames()) {
+            throw new IllegalArgumentException("A header name is missing in " + Arrays.toString(headerRecord));
+        }
+        final boolean containsHeader = blankHeader ? observedMissing : headerMap.containsKey(header);
+        final DuplicateHeaderMode headerMode = format.getDuplicateHeaderMode();
+        final boolean duplicatesAllowed = headerMode == DuplicateHeaderMode.ALLOW_ALL;
+        final boolean emptyDuplicatesAllowed = headerMode == DuplicateHeaderMode.ALLOW_EMPTY;
+        if (containsHeader && !duplicatesAllowed && !(blankHeader && emptyDuplicatesAllowed)) {
+            throw new IllegalArgumentException(String.format(
+                    "The header contains a duplicate name: \"%s\" in %s. If this is valid then use CSVFormat.Builder.setDuplicateHeaderMode().", header,
+                    Arrays.toString(headerRecord)));
+        }
     }
 
     /**
@@ -905,41 +926,53 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         do {
             reusableToken.reset();
             lexer.nextToken(reusableToken);
-            switch (reusableToken.type) {
-            case TOKEN:
-                addRecordValue(false);
-                break;
-            case EORECORD:
-                addRecordValue(true);
-                break;
-            case EOF:
-                if (reusableToken.isReady) {
-                    addRecordValue(true);
-                } else if (sb != null) {
-                    trailerComment = sb.toString();
-                }
-                break;
-            case INVALID:
-                throw new CSVException("(line %,d) invalid parse sequence", getCurrentLineNumber());
-            case COMMENT: // Ignored currently
-                if (sb == null) { // first comment for this record
-                    sb = new StringBuilder();
-                } else {
-                    sb.append(Constants.LF);
-                }
-                sb.append(reusableToken.content);
-                reusableToken.type = TOKEN; // Read another token
-                break;
-            default:
-                throw new CSVException("Unexpected Token type: %s", reusableToken.type);
-            }
+            sb = handleToken(sb);
         } while (reusableToken.type == TOKEN);
         if (!recordList.isEmpty()) {
             recordNumber++;
-            result = new CSVRecord(this, recordList.toArray(Constants.EMPTY_STRING_ARRAY), Objects.toString(sb, null), recordNumber, startCharPosition,
-                    startBytePosition);
+            result = createRecord(sb, startCharPosition, startBytePosition);
         }
         return result;
+    }
+
+    private StringBuilder handleToken(final StringBuilder comments) throws IOException {
+        switch (reusableToken.type) {
+        case TOKEN:
+            addRecordValue(false);
+            return comments;
+        case EORECORD:
+            addRecordValue(true);
+            return comments;
+        case EOF:
+            handleEndOfFile(comments);
+            return comments;
+        case INVALID:
+            throw new CSVException("(line %,d) invalid parse sequence", getCurrentLineNumber());
+        case COMMENT:
+            return appendComment(comments);
+        default:
+            throw new CSVException("Unexpected Token type: %s", reusableToken.type);
+        }
+    }
+
+    private void handleEndOfFile(final StringBuilder comments) {
+        if (reusableToken.isReady) {
+            addRecordValue(true);
+        } else if (comments != null) {
+            trailerComment = comments.toString();
+        }
+    }
+
+    private StringBuilder appendComment(final StringBuilder comments) {
+        final StringBuilder commentBuffer = comments == null ? new StringBuilder() : comments.append(Constants.LF);
+        commentBuffer.append(reusableToken.content);
+        reusableToken.type = TOKEN; // Read another token
+        return commentBuffer;
+    }
+
+    private CSVRecord createRecord(final StringBuilder comments, final long startCharPosition, final long startBytePosition) {
+        return new CSVRecord(this, recordList.toArray(Constants.EMPTY_STRING_ARRAY), Objects.toString(comments, null), recordNumber, startCharPosition,
+                startBytePosition);
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/CSVPrinter.java
+++ b/src/main/java/org/apache/commons/csv/CSVPrinter.java
@@ -111,12 +111,20 @@ public final class CSVPrinter implements Flushable, Closeable {
         this.format = format.copy();
         // TODO: Is it a good idea to do this here instead of on the first call to a print method?
         // It seems a pain to have to track whether the header has already been printed or not.
+        printHeaderComments(format);
+        printHeaderRecord(format);
+    }
+
+    private void printHeaderComments(final CSVFormat format) throws IOException {
         final String[] headerComments = format.getHeaderComments();
         if (headerComments != null) {
             for (final String line : headerComments) {
                 printComment(line);
             }
         }
+    }
+
+    private void printHeaderRecord(final CSVFormat format) throws IOException {
         if (format.getHeader() != null && !format.getSkipHeaderRecord()) {
             this.printRecord((Object[]) format.getHeader());
         }
@@ -235,8 +243,7 @@ public final class CSVPrinter implements Flushable, Closeable {
             if (!newRecord) {
                 println();
             }
-            appendable.append(format.getCommentMarker().charValue()); // Explicit unboxing is intentional
-            appendable.append(SP);
+            appendCommentStart();
             for (int i = 0; i < comment.length(); i++) {
                 final char c = comment.charAt(i);
                 switch (c) {
@@ -247,8 +254,7 @@ public final class CSVPrinter implements Flushable, Closeable {
                     // falls-through: break intentionally excluded.
                 case LF:
                     println();
-                    appendable.append(format.getCommentMarker().charValue()); // Explicit unboxing is intentional
-                    appendable.append(SP);
+                    appendCommentStart();
                     break;
                 default:
                     appendable.append(c);
@@ -259,6 +265,11 @@ public final class CSVPrinter implements Flushable, Closeable {
         } finally {
             lock.unlock();
         }
+    }
+
+    private void appendCommentStart() throws IOException {
+        appendable.append(format.getCommentMarker().charValue()); // Explicit unboxing is intentional
+        appendable.append(SP);
     }
 
     /**
@@ -491,24 +502,31 @@ public final class CSVPrinter implements Flushable, Closeable {
         while (resultSet.next() && format.useRow(resultSet.getRow())) {
             lock.lock();
             try {
-                for (int i = 1; i <= columnCount; i++) {
-                    final Object object = resultSet.getObject(i);
-                    if (object instanceof Clob) {
-                        try (Reader reader = ((Clob) object).getCharacterStream()) {
-                            print(reader);
-                        }
-                    } else if (object instanceof Blob) {
-                        try (InputStream inputStream = ((Blob) object).getBinaryStream()) {
-                            print(inputStream);
-                        }
-                    } else {
-                        print(object);
-                    }
-                }
+                printResultSetRow(resultSet, columnCount);
                 endOfRecord();
             } finally {
                 lock.unlock();
             }
+        }
+    }
+
+    private void printResultSetRow(final ResultSet resultSet, final int columnCount) throws SQLException, IOException {
+        for (int i = 1; i <= columnCount; i++) {
+            printResultSetValue(resultSet.getObject(i));
+        }
+    }
+
+    private void printResultSetValue(final Object object) throws SQLException, IOException {
+        if (object instanceof Clob) {
+            try (Reader reader = ((Clob) object).getCharacterStream()) {
+                print(reader);
+            }
+        } else if (object instanceof Blob) {
+            try (InputStream inputStream = ((Blob) object).getBinaryStream()) {
+                print(inputStream);
+            }
+        } else {
+            print(object);
         }
     }
 

--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -123,21 +123,19 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      * @see CSVFormat.Builder#setNullString(String)
      */
     public String get(final String name) {
-        final Map<String, Integer> headerMap = getHeaderMapRaw();
-        if (headerMap == null) {
-            throw new IllegalStateException("No header mapping was specified, the record values can't be accessed by name");
-        }
-        final Integer index = headerMap.get(name);
-        if (index == null) {
-            throw new IllegalArgumentException(String.format("Mapping for %s not found, expected one of %s", name, headerMap.keySet()));
-        }
+        final Map<String, Integer> headerMap = requireHeaderMap();
+        final Integer index = requireMappedIndex(name, headerMap);
         try {
             return values[index.intValue()]; // Explicit unboxing is intentional
         } catch (final ArrayIndexOutOfBoundsException e) {
-            // Explicit boxing is intentional
-            throw new IllegalArgumentException(
-                    String.format("Index for header '%s' is %d but CSVRecord only has %d values!", name, index, Integer.valueOf(values.length)));
+            throw inconsistentRecordException(name, index);
         }
+    }
+
+    private IllegalArgumentException inconsistentRecordException(final String name, final Integer index) {
+        // Explicit boxing is intentional
+        return new IllegalArgumentException(
+                String.format("Index for header '%s' is %d but CSVRecord only has %d values!", name, index, Integer.valueOf(values.length)));
     }
 
     /**
@@ -174,6 +172,22 @@ public final class CSVRecord implements Serializable, Iterable<String> {
 
     private Map<String, Integer> getHeaderMapRaw() {
         return parser == null ? null : parser.getHeaderMapRaw();
+    }
+
+    private Integer requireMappedIndex(final String name, final Map<String, Integer> headerMap) {
+        final Integer index = headerMap.get(name);
+        if (index == null) {
+            throw new IllegalArgumentException(String.format("Mapping for %s not found, expected one of %s", name, headerMap.keySet()));
+        }
+        return index;
+    }
+
+    private Map<String, Integer> requireHeaderMap() {
+        final Map<String, Integer> headerMap = getHeaderMapRaw();
+        if (headerMap == null) {
+            throw new IllegalStateException("No header mapping was specified, the record values can't be accessed by name");
+        }
+        return headerMap;
     }
 
     /**
@@ -265,7 +279,11 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      * @return whether a given column is mapped and has a value.
      */
     public boolean isSet(final String name) {
-        return isMapped(name) && getHeaderMapRaw().get(name).intValue() < values.length; // Explicit unboxing is intentional
+        return isMapped(name) && isMappedIndexSet(name);
+    }
+
+    private boolean isMappedIndexSet(final String name) {
+        return getHeaderMapRaw().get(name).intValue() < values.length; // Explicit unboxing is intentional
     }
 
     /**
@@ -287,15 +305,18 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      * @since 1.9.0
      */
     public <M extends Map<String, String>> M putIn(final M map) {
-        if (getHeaderMapRaw() == null) {
+        final Map<String, Integer> headerMap = getHeaderMapRaw();
+        if (headerMap == null) {
             return map;
         }
-        getHeaderMapRaw().forEach((key, value) -> {
-            if (value < values.length) {
-                map.put(key, values[value]);
-            }
-        });
+        headerMap.forEach((key, value) -> putMappedValue(map, key, value.intValue()));
         return map;
+    }
+
+    private <M extends Map<String, String>> void putMappedValue(final M map, final String key, final int valueIndex) {
+        if (valueIndex < values.length) {
+            map.put(key, values[valueIndex]);
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
+++ b/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
@@ -162,6 +162,37 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
         throw new CharacterCodingException();
     }
 
+    private void incrementBytesRead(final int current) throws CharacterCodingException {
+        if (encoder != null && current != EOF) {
+            this.bytesRead += getEncodedCharLength(current);
+        }
+    }
+
+    private void incrementBytesRead(final char[] buf, final int offset, final int length) throws CharacterCodingException {
+        if (encoder != null && length > 0) {
+            this.bytesRead += getEncodedCharLength(buf, offset, length);
+        }
+    }
+
+    private void incrementLineNumber(final int current) {
+        if (current == CR || current == LF && lastChar != CR || current == EOF && lastChar != CR && lastChar != LF && lastChar != EOF) {
+            lineNumber++;
+        }
+    }
+
+    private void incrementLineNumber(final char[] buf, final int offset, final int length) {
+        for (int i = offset; i < offset + length; i++) {
+            final char ch = buf[i];
+            if (ch == LF) {
+                if (CR != (i > offset ? buf[i - 1] : lastChar)) {
+                    lineNumber++;
+                }
+            } else if (ch == CR) {
+                lineNumber++;
+            }
+        }
+    }
+
     /**
      * Returns the last character that was read as an integer (0 to 65535). This will be the last character returned by any of the read methods. This will not
      * include a character read using the {@link #peek()} method. If no character has been read then this will return {@link Constants#UNDEFINED}. If the end of
@@ -207,12 +238,8 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
     @Override
     public int read() throws IOException {
         final int current = super.read();
-        if (current == CR || current == LF && lastChar != CR || current == EOF && lastChar != CR && lastChar != LF && lastChar != EOF) {
-            lineNumber++;
-        }
-        if (encoder != null && current != EOF) {
-            this.bytesRead += getEncodedCharLength(current);
-        }
+        incrementLineNumber(current);
+        incrementBytesRead(current);
         lastChar = current;
         position++;
         return lastChar;
@@ -224,20 +251,9 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
             return 0;
         }
         final int len = super.read(buf, offset, length);
-        if (encoder != null && len > 0) {
-            this.bytesRead += getEncodedCharLength(buf, offset, len);
-        }
+        incrementBytesRead(buf, offset, len);
         if (len > 0) {
-            for (int i = offset; i < offset + len; i++) {
-                final char ch = buf[i];
-                if (ch == LF) {
-                    if (CR != (i > offset ? buf[i - 1] : lastChar)) {
-                        lineNumber++;
-                    }
-                } else if (ch == CR) {
-                    lineNumber++;
-                }
-            }
+            incrementLineNumber(buf, offset, len);
             lastChar = buf[offset + len - 1];
         } else if (len == EOF) {
             lastChar = EOF;

--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -349,30 +349,7 @@ final class Lexer implements Closeable {
                     c = reader.read();
                     token.content.append((char) c);
                 } else {
-                    // token finish mark (encapsulator) reached: ignore whitespace till delimiter
-                    while (true) {
-                        c = reader.read();
-                        if (isDelimiter(c)) {
-                            token.type = Token.Type.TOKEN;
-                            return token;
-                        }
-                        if (isEndOfFile(c)) {
-                            token.type = Token.Type.EOF;
-                            token.isReady = true; // There is data at EOF
-                            return token;
-                        }
-                        if (readEndOfLine(c)) {
-                            token.type = Token.Type.EORECORD;
-                            return token;
-                        }
-                        if (trailingData) {
-                            token.content.append((char) c);
-                        } else if (!Character.isWhitespace((char) c)) {
-                            // error invalid char between token and next delimiter
-                            throw new CSVException("Invalid character between encapsulated token and delimiter at line: %,d, position: %,d",
-                                    getCurrentLineNumber(), getCharacterPosition());
-                        }
-                    }
+                    return finishEncapsulatedToken(token);
                 }
             } else if (isEscape(c)) {
                 appendNextEscapedCharacterToToken(token);
@@ -388,6 +365,37 @@ final class Lexer implements Closeable {
                 // consume character
                 token.content.append((char) c);
             }
+        }
+    }
+
+    private Token finishEncapsulatedToken(final Token token) throws IOException {
+        // token finish mark (encapsulator) reached: ignore whitespace till delimiter
+        while (true) {
+            final int c = reader.read();
+            if (isDelimiter(c)) {
+                token.type = Token.Type.TOKEN;
+                return token;
+            }
+            if (isEndOfFile(c)) {
+                token.type = Token.Type.EOF;
+                token.isReady = true; // There is data at EOF
+                return token;
+            }
+            if (readEndOfLine(c)) {
+                token.type = Token.Type.EORECORD;
+                return token;
+            }
+            handleTrailingCharacter(token, c);
+        }
+    }
+
+    private void handleTrailingCharacter(final Token token, final int c) throws CSVException {
+        if (trailingData) {
+            token.content.append((char) c);
+        } else if (!Character.isWhitespace((char) c)) {
+            // error invalid char between token and next delimiter
+            throw new CSVException("Invalid character between encapsulated token and delimiter at line: %,d, position: %,d", getCurrentLineNumber(),
+                    getCharacterPosition());
         }
     }
 
@@ -482,6 +490,22 @@ final class Lexer implements Closeable {
     int readEscape() throws IOException {
         // the escape char has just been read (normally a backslash)
         final int ch = reader.read();
+        final int translated = translateEscape(ch);
+        if (translated != EOF) {
+            return translated;
+        }
+        if (ch == EOF) {
+            throw new CSVException("EOF while processing escape sequence");
+        }
+        // Now check for meta-characters
+        if (isMetaChar(ch)) {
+            return ch;
+        }
+        // indicate unexpected char - available from in.getLastChar()
+        return EOF;
+    }
+
+    private int translateEscape(final int ch) {
         switch (ch) {
         case 'r':
             return Constants.CR;
@@ -499,14 +523,7 @@ final class Lexer implements Closeable {
         case Constants.TAB: // TODO is this correct? Do tabs need to be escaped?
         case Constants.BACKSPACE: // TODO is this correct?
             return ch;
-        case EOF:
-            throw new CSVException("EOF while processing escape sequence");
         default:
-            // Now check for meta-characters
-            if (isMetaChar(ch)) {
-                return ch;
-            }
-            // indicate unexpected char - available from in.getLastChar()
             return EOF;
         }
     }

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -870,19 +870,10 @@ class CSVParserTest {
         }
     }
 
-    @Test
-    void testGetLineNumberWithCR() throws Exception {
-        validateLineNumbers(String.valueOf(CR));
-    }
-
-    @Test
-    void testGetLineNumberWithCRLF() throws Exception {
-        validateLineNumbers(CRLF);
-    }
-
-    @Test
-    void testGetLineNumberWithLF() throws Exception {
-        validateLineNumbers(String.valueOf(LF));
+    @ParameterizedTest
+    @ValueSource(strings = { "\r", "\r\n", "\n" })
+    void testGetLineNumber(final String lineSeparator) throws Exception {
+        validateLineNumbers(lineSeparator);
     }
 
     @Test
@@ -952,29 +943,16 @@ class CSVParserTest {
         }
     }
 
-    @Test
-    void testGetRecordNumberWithCR() throws Exception {
-        validateRecordNumbers(String.valueOf(CR));
+    @ParameterizedTest
+    @ValueSource(strings = { "\r", "\r\n", "\n" })
+    void testGetRecordNumber(final String lineSeparator) throws Exception {
+        validateRecordNumbers(lineSeparator);
     }
 
-    @Test
-    void testGetRecordNumberWithCRLF() throws Exception {
-        validateRecordNumbers(CRLF);
-    }
-
-    @Test
-    void testGetRecordNumberWithLF() throws Exception {
-        validateRecordNumbers(String.valueOf(LF));
-    }
-
-    @Test
-    void testGetRecordPositionWithCRLF() throws Exception {
-        validateRecordPosition(CRLF);
-    }
-
-    @Test
-    void testGetRecordPositionWithLF() throws Exception {
-        validateRecordPosition(String.valueOf(LF));
+    @ParameterizedTest
+    @ValueSource(strings = { "\r\n", "\n" })
+    void testGetRecordPosition(final String lineSeparator) throws Exception {
+        validateRecordPosition(lineSeparator);
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR performs behavior-preserving refactors for maintainability hotspots identified in the code-smell report.

Changes include:
- Extracted private helpers in CSVFormat, CSVParser, Lexer, ExtendedBufferedReader, CSVPrinter, and CSVRecord.
- Reduced complex private method bodies without changing public behavior.
- Preserved public APIs, deprecated compatibility methods, predefined dialect constants, and existing semantics.
- Consolidated a small duplicated parser-test pattern using parameterized tests.

## Validation
- mvn clean test
- mvn verify

Both passed with:
- 944 tests
- 0 failures
- 0 errors
- 11 skipped

## Notes
These changes are focused only on maintainability/code-smell reduction and are intended to preserve existing Apache Commons CSV functionality.