### PR TITLE
Evaluate isDelimiter once in nextToken whitespace skip

### DIFF
--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -277,15 +277,22 @@ final class Lexer implements Closeable {
         }
         // Important: make sure a new char gets consumed in each iteration
         while (token.type == Token.Type.INVALID) {
+            // isDelimiter consumes the trailing characters of a multi-character delimiter as a side effect, so it must
+            // only be evaluated once per character. Remember a match found while skipping whitespace below.
+            boolean delimiter = false;
             // ignore whitespaces at beginning of a token
             if (ignoreSurroundingSpaces) {
-                while (Character.isWhitespace((char) c) && !isDelimiter(c) && !eol) {
+                while (Character.isWhitespace((char) c) && !eol) {
+                    if (isDelimiter(c)) {
+                        delimiter = true;
+                        break;
+                    }
                     c = reader.read();
                     eol = readEndOfLine(c);
                 }
             }
             // ok, start of token reached: encapsulated, or token
-            if (isDelimiter(c)) {
+            if (delimiter || isDelimiter(c)) {
                 // empty token return TOKEN("")
                 token.type = Token.Type.TOKEN;
             } else if (eol) {

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1758,6 +1758,26 @@ class CSVParserTest {
         }
     }
 
+    /**
+     * With {@code ignoreSurroundingSpaces} enabled and a multi-character delimiter whose first character is whitespace,
+     * the empty field at the delimiter boundary must survive. The delimiter look-ahead is consumed while skipping
+     * leading whitespace, so re-evaluating it would drop the empty field and merge the following field's value.
+     */
+    @Test
+    void testEmptyFieldBeforeWhitespacePrefixedMultiCharacterDelimiter() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter(" |").setIgnoreSurroundingSpaces(true).get();
+        try (CSVParser parser = CSVParser.parse(" |a", format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertValuesEquals(new String[] { "", "a" }, records.get(0));
+        }
+        try (CSVParser parser = CSVParser.parse("a | |b", format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(1, records.size());
+            assertValuesEquals(new String[] { "a", "", "b" }, records.get(0));
+        }
+    }
+
     @Test
     void testProvidedHeader() throws Exception {
         final Reader in = new StringReader("a,b,c\n1,2,3\nx,y,z");

--- a/src/test/java/org/apache/commons/csv/LexerTest.java
+++ b/src/test/java/org/apache/commons/csv/LexerTest.java
@@ -447,6 +447,25 @@ class LexerTest {
         }
     }
 
+    /**
+     * With {@code ignoreSurroundingSpaces} enabled and a multi-character delimiter whose first character is whitespace,
+     * the side-effecting {@link Lexer#isDelimiter(int)} must only be evaluated once per character, otherwise the
+     * delimiter is consumed in the whitespace-skip loop and the empty field at the boundary is dropped.
+     */
+    @Test
+    void testEmptyTokenBeforeWhitespacePrefixedMultiCharacterDelimiter() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter(" |").setIgnoreSurroundingSpaces(true).get();
+        try (Lexer lexer = createLexer(" |a", format)) {
+            assertNextToken(TOKEN, "", lexer);
+            assertNextToken(EOF, "a", lexer);
+        }
+        try (Lexer lexer = createLexer("a | |b", format)) {
+            assertNextToken(TOKEN, "a", lexer);
+            assertNextToken(TOKEN, "", lexer);
+            assertNextToken(EOF, "b", lexer);
+        }
+    }
+
     @Test
     void testReadEscapeBackspace() throws IOException {
         try (Lexer lexer = createLexer("b", CSVFormat.DEFAULT.withEscape('\b'))) {


### PR DESCRIPTION
`nextToken` evaluates the side-effecting `isDelimiter(c)` twice on the same character when `ignoreSurroundingSpaces` is on: once in the leading-whitespace skip loop and again in the start-of-token check. `isDelimiter` consumes the trailing characters of a multi-character delimiter as it matches, so for a delimiter whose first character is whitespace the loop eats the delimiter and the second call then peeks past it, mismatches, and the empty field at that boundary is dropped. With delimiter `" |"` and `ignoreSurroundingSpaces` enabled, `a | |b` parsed to two fields (`a`, `" b"`) instead of three (`a`, empty, `b`), and ` |a` to one field (`" a"`) instead of two (empty, `a`). Fixed by evaluating `isDelimiter` once in the whitespace loop and reusing that result for the start-of-token decision.

Found while auditing the multi-character delimiter look-ahead against `ignoreSurroundingSpaces`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
