### PR TITLE
Quote value ending with multi-character delimiter prefix

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2098,6 +2098,33 @@ public final class CSVFormat implements Serializable {
     }
 
     /**
+     * Tests whether appending the delimiter after {@code charSeq} would let the parser match the delimiter starting inside the value. This happens with a
+     * multi-character delimiter when the value ends with a straddling prefix of it (for delimiter {@code ||}, a value ending in {@code |} followed by the
+     * delimiter yields {@code |||}, which the greedy lexer splits one character early). Such a value must be encapsulated so the field boundary is unambiguous.
+     */
+    private boolean endsWithDelimiterPrefix(final CharSequence charSeq, final char[] delimiter, final int delimiterLength) {
+        if (delimiterLength < 2) {
+            return false;
+        }
+        final int len = charSeq.length();
+        for (int start = Math.max(0, len - delimiterLength + 1); start < len; start++) {
+            boolean match = true;
+            for (int j = 0; j < delimiterLength; j++) {
+                final int idx = start + j;
+                final char c = idx < len ? charSeq.charAt(idx) : delimiter[idx - len];
+                if (c != delimiter[j]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Tests whether escapes are being processed.
      *
      * @return {@code true} if escapes are processed
@@ -2509,6 +2536,9 @@ public final class CSVFormat implements Serializable {
                         // Some other chars at the end caused the parser to fail, so for now
                         // encapsulate if we end in anything less than ' '
                         if (isTrimChar(c)) {
+                            quote = true;
+                        } else if (endsWithDelimiterPrefix(charSeq, delim, delimLength)) {
+                            // A trailing partial multi-character delimiter would merge with the following delimiter on read.
                             quote = true;
                         }
                     }

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -1931,6 +1931,30 @@ class CSVPrinterTest {
     }
 
     @Test
+    void testQuoteValueEndingWithSupplementaryDelimiterPrefix() throws IOException {
+        // Supplementary code point (surrogate pair) used inside a multi-character delimiter.
+        final String clef = new String(Character.toChars(0x1D11E));
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter(clef + clef).get();
+        final StringWriter sw = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            // Value ending in one clef is a straddling prefix of the two-clef delimiter and must be quoted.
+            printer.printRecord("a" + clef, "b");
+            // Value not ending in a delimiter prefix stays unquoted.
+            printer.printRecord("ab", "c");
+        }
+        final String string = sw.toString();
+        assertEquals("\"a" + clef + "\"" + clef + clef + "b" + RECORD_SEPARATOR + "ab" + clef + clef + "c" + RECORD_SEPARATOR, string);
+        try (CSVParser parser = CSVParser.parse(string, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(2, records.size());
+            assertEquals("a" + clef, records.get(0).get(0));
+            assertEquals("b", records.get(0).get(1));
+            assertEquals("ab", records.get(1).get(0));
+            assertEquals("c", records.get(1).get(1));
+        }
+    }
+
+    @Test
     void testQuoteNonNumeric() throws IOException {
         final StringWriter sw = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuoteMode(QuoteMode.NON_NUMERIC))) {

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -1909,6 +1909,28 @@ class CSVPrinterTest {
     }
 
     @Test
+    void testQuoteValueEndingWithMultiCharacterDelimiterPrefix() throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setDelimiter("||").get();
+        final StringWriter sw = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            // "a|" ends with the delimiter's first char; unquoted output "a|||b" would split one char early on read.
+            printer.printRecord("a|", "b");
+            // "a|b" does not end with a delimiter prefix, so it stays unquoted.
+            printer.printRecord("a|b", "c");
+        }
+        final String string = sw.toString();
+        assertEquals("\"a|\"||b" + RECORD_SEPARATOR + "a|b||c" + RECORD_SEPARATOR, string);
+        try (CSVParser parser = CSVParser.parse(string, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(2, records.size());
+            assertEquals("a|", records.get(0).get(0));
+            assertEquals("b", records.get(0).get(1));
+            assertEquals("a|b", records.get(1).get(0));
+            assertEquals("c", records.get(1).get(1));
+        }
+    }
+
+    @Test
     void testQuoteNonNumeric() throws IOException {
         final StringWriter sw = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.withQuoteMode(QuoteMode.NON_NUMERIC))) {


### PR DESCRIPTION
`printWithQuotes` in MINIMAL quote mode does not encapsulate a value whose tail is a straddling prefix of a multi-character delimiter, so the printed record cannot be read back. With delimiter `||`, a field ending in `|` such as `a|` is written unquoted, and the record `a|||b` is then parsed by `CSVParser` as `[a, |b]` because the greedy lexer matches the delimiter one character early at the value/delimiter boundary. The existing scan only quotes when the full delimiter occurs inside the value; a trailing partial delimiter slips through. Fixed by `endsWithDelimiterPrefix`, which quotes the value when appending the delimiter after it would create a boundary-straddling delimiter match. Single-character delimiters and values that contain the delimiter start without a straddling suffix (for example delimiter `[|]`, value `a[`) are unaffected.

Found while auditing multi-character delimiter round-trips through the printer.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.