### PR TITLE
Quote value with leading or trailing Unicode whitespace

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2514,11 +2514,12 @@ public final class CSVFormat implements Serializable {
                 }
             } else {
                 char c = charSeq.charAt(pos);
-                if (c <= Constants.COMMENT || isCommentMarkerSet() && c == commentMarker.charValue()) {
+                if (c <= Constants.COMMENT || Character.isWhitespace(c) || isCommentMarkerSet() && c == commentMarker.charValue()) {
                     // Some other chars at the start of a value caused the parser to fail, so for now
                     // encapsulate if we start in anything less than '#'. We are being conservative
                     // by including the default comment char and any configured comment marker too,
-                    // which the parser would otherwise read back as a comment line.
+                    // which the parser would otherwise read back as a comment line. A leading Unicode
+                    // whitespace above ' ' is stripped by ignoreSurroundingSpaces on read, so quote it too.
                     quote = true;
                 } else {
                     while (pos < len) {
@@ -2534,8 +2535,9 @@ public final class CSVFormat implements Serializable {
                         pos = len - 1;
                         c = charSeq.charAt(pos);
                         // Some other chars at the end caused the parser to fail, so for now
-                        // encapsulate if we end in anything less than ' '
-                        if (isTrimChar(c)) {
+                        // encapsulate if we end in anything less than ' '. A trailing Unicode whitespace
+                        // above ' ' is stripped by ignoreSurroundingSpaces on read, so quote it too.
+                        if (isTrimChar(c) || Character.isWhitespace(c)) {
                             quote = true;
                         } else if (endsWithDelimiterPrefix(charSeq, delim, delimLength)) {
                             // A trailing partial multi-character delimiter would merge with the following delimiter on read.

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -1964,6 +1964,30 @@ class CSVPrinterTest {
     }
 
     @Test
+    void testQuoteValueWithLeadingOrTrailingUnicodeWhitespace() throws IOException {
+        // U+3000 IDEOGRAPHIC SPACE is Character.isWhitespace but greater than ' ', so ignoreSurroundingSpaces
+        // strips it on read. It must be quoted or the surrounding whitespace is lost on a round trip.
+        final String idSpace = "　";
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setIgnoreSurroundingSpaces(true).get();
+        final StringWriter sw = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            printer.printRecord(idSpace + "a" + idSpace, "b");
+            // A value without surrounding whitespace stays unquoted.
+            printer.printRecord("ab", "c");
+        }
+        final String string = sw.toString();
+        assertEquals("\"" + idSpace + "a" + idSpace + "\",b" + RECORD_SEPARATOR + "ab,c" + RECORD_SEPARATOR, string);
+        try (CSVParser parser = CSVParser.parse(string, format)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(2, records.size());
+            assertEquals(idSpace + "a" + idSpace, records.get(0).get(0));
+            assertEquals("b", records.get(0).get(1));
+            assertEquals("ab", records.get(1).get(0));
+            assertEquals("c", records.get(1).get(1));
+        }
+    }
+
+    @Test
     void testRandomDefault() throws Exception {
         doRandom(CSVFormat.DEFAULT, ITERATIONS_FOR_RANDOM_TEST);
     }


### PR DESCRIPTION
`printWithQuotes` decides MINIMAL-mode encapsulation from the first and last character, but only against ascii bounds: `c <= Constants.COMMENT` for the leading char and `isTrimChar` (`c <= ' '`) for the trailing one. The parser's `ignoreSurroundingSpaces` strips any `Character.isWhitespace` on read, and several whitespace code points sit above `' '` (U+3000 ideographic space, U+2028/U+2029, U+2003, U+1680, U+205F, U+2000..U+200A). A value bounded by one of them, such as `　a　`, is written unquoted and read back trimmed to `a`. Quote when the first or last character is `Character.isWhitespace`, matching what the reader trims. `isTrimChar` is left alone since it is shared with the `getTrim` path that mirrors `String.trim`.

Found while round-tripping unicode whitespace through the printer with `ignoreSurroundingSpaces`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
