### PR TITLE
Exclude byte-order mark from ExtendedBufferedReader byte counting

### DIFF
--- a/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
+++ b/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
@@ -66,6 +66,9 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
     /** Encoder for calculating the number of bytes for each character read. */
     private final CharsetEncoder encoder;
 
+    /** Bytes {@link #encoder} emits as a byte-order mark on every {@link CharsetEncoder#encode(CharBuffer)} call (for example {@code UTF-16}). */
+    private final int bomLength;
+
     /**
      * Constructs a new instance using the default buffer size.
      */
@@ -84,6 +87,7 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
     ExtendedBufferedReader(final Reader reader, final Charset charset, final boolean trackBytes) {
         super(reader);
         encoder = charset != null && trackBytes ? charset.newEncoder() : null;
+        bomLength = encoder != null ? measureBomLength(encoder) : 0;
     }
 
     /**
@@ -150,16 +154,33 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
         final char cChar = (char) current;
         final char lChar = (char) previous;
         if (!Character.isSurrogate(cChar)) {
-            return encoder.encode(CharBuffer.wrap(new char[] { cChar })).limit();
+            return encoder.encode(CharBuffer.wrap(new char[] { cChar })).limit() - bomLength;
         }
         if (Character.isHighSurrogate(cChar)) {
             // Move on to the next char (low surrogate)
             return 0;
         }
         if (Character.isSurrogatePair(lChar, cChar)) {
-            return encoder.encode(CharBuffer.wrap(new char[] { lChar, cChar })).limit();
+            return encoder.encode(CharBuffer.wrap(new char[] { lChar, cChar })).limit() - bomLength;
         }
         throw new CharacterCodingException();
+    }
+
+    /**
+     * Measures the byte-order mark that {@code encoder} prepends to every {@link CharsetEncoder#encode(CharBuffer)} call. Charsets such as {@code UTF-16} emit
+     * a BOM each time, which would otherwise be counted once per character. The BOM is the constant prefix shared by encoding one and two characters.
+     *
+     * @param encoder The encoder to measure.
+     * @return The byte-order mark length in bytes, or 0 when the encoder writes none.
+     */
+    private static int measureBomLength(final CharsetEncoder encoder) {
+        try {
+            final int one = encoder.encode(CharBuffer.wrap(new char[] { 'a' })).limit();
+            final int two = encoder.encode(CharBuffer.wrap(new char[] { 'a', 'a' })).limit();
+            return Math.max(0, 2 * one - two);
+        } catch (final CharacterCodingException e) {
+            return 0;
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -768,6 +768,29 @@ class CSVParserTest {
     }
 
     @Test
+    void testGetBytePositionWithBomEmittingCharset() throws IOException {
+        // The UTF-16 encoder writes a byte-order mark on every encode call, so the per-character
+        // byte length must exclude it. Otherwise each code unit is counted as 4 bytes (2 for the
+        // BOM, 2 for the char) and getBytePosition() grows at twice the true rate.
+        final String code = "a,b\nc,d\n";
+        try (CSVParser parser = CSVParser.builder()
+                .setReader(new StringReader(code))
+                .setFormat(CSVFormat.DEFAULT)
+                .setCharset(StandardCharsets.UTF_16)
+                .setTrackBytes(true)
+                .get()) {
+            final CSVRecord first = parser.nextRecord();
+            final CSVRecord second = parser.nextRecord();
+            assertNotNull(first);
+            assertNotNull(second);
+            assertNull(parser.nextRecord());
+            assertEquals(0, first.getBytePosition());
+            // "a,b\n" is 4 UTF-16 code units, 2 bytes each.
+            assertEquals(8, second.getBytePosition());
+        }
+    }
+
+    @Test
     void testGetHeaderComment_HeaderComment1() throws IOException {
         try (CSVParser parser = CSVParser.parse(CSV_INPUT_HEADER_COMMENT, FORMAT_AUTO_HEADER)) {
             parser.getRecords();


### PR DESCRIPTION
`getEncodedCharLength` re-encodes each character with the configured `CharsetEncoder` to count its bytes, but the convenience `encode` call re-emits a byte-order mark on every invocation for charsets like `UTF-16`. Parsing a UTF-16 stream with `setTrackBytes(true)`, for example an Excel Unicode export, counts every code unit as 4 bytes instead of 2, so `CSVRecord.getBytePosition()` grows at twice the true rate. Found by comparing reported byte offsets against the encoded prefix length across charsets.

Measure the per-call BOM once and subtract it from each encoded length. The count already lives in `getEncodedCharLength`, so keeping the adjustment there covers both the single-char and array read paths, and it stays a no-op for charsets that emit no BOM (`UTF-8`, `UTF-16LE`/`BE`, single-byte).
