### PR TITLE
Fill the lookahead buffer on short reads from a chunked source

### DIFF
--- a/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
+++ b/src/main/java/org/apache/commons/csv/ExtendedBufferedReader.java
@@ -225,6 +225,37 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
         super.mark(readAheadLimit);
     }
 
+    /**
+     * Fills {@code array} with the characters that follow the current position without consuming them.
+     * <p>
+     * Overridden because the inherited implementation stops at the first short read, which leaves the tail of the array holding stale content when the source
+     * delivers data in chunks. Callers compare the whole array against a multi-character delimiter, so a partial fill makes them miss a delimiter that is
+     * really there.
+     * </p>
+     *
+     * @param array the buffer to fill.
+     * @return the number of characters peeked, or {@link IOUtils#EOF} at the end of the stream.
+     * @throws IOException If an I/O error occurs.
+     */
+    @Override
+    public int peek(final char[] array) throws IOException {
+        final int length = array.length;
+        if (length == 0) {
+            return 0;
+        }
+        super.mark(length);
+        int len = 0;
+        while (len < length) {
+            final int more = super.read(array, len, length - len);
+            if (more == EOF) {
+                break;
+            }
+            len += more;
+        }
+        super.reset();
+        return len == 0 ? EOF : len;
+    }
+
     @Override
     public int read() throws IOException {
         final int current = super.read();
@@ -244,7 +275,16 @@ final class ExtendedBufferedReader extends UnsynchronizedBufferedReader {
         if (length == 0) {
             return 0;
         }
-        final int len = super.read(buf, offset, length);
+        int len = super.read(buf, offset, length);
+        // The underlying buffered reader stops early once the source reports it is not ready, so a stream that delivers data in chunks (a socket or a pipe)
+        // yields a short read. Callers match multi-character sequences against this buffer, so keep reading until it is full or the source is exhausted.
+        while (len > 0 && len < length) {
+            final int more = super.read(buf, offset + len, length - len);
+            if (more == EOF) {
+                break;
+            }
+            len += more;
+        }
         if (encoder != null && len > 0) {
             this.bytesRead += getEncodedCharLength(buf, offset, len);
         }

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1711,36 +1711,8 @@ class CSVParserTest {
 
     @Test
     void testParseWithDelimiterStringFromChunkedReader() throws IOException {
-        // A reader that hands out one character at a time and never reports itself ready, like a socket or pipe.
-        final Reader chunked = new Reader() {
-
-            private final String content = "a[|]b\r\nc![!|!]d[|]e";
-            private int index;
-
-            @Override
-            public void close() {
-                // nothing to close
-            }
-
-            @Override
-            public boolean ready() {
-                return false;
-            }
-
-            @Override
-            public int read(final char[] buf, final int offset, final int length) {
-                if (index >= content.length()) {
-                    return -1;
-                }
-                if (length <= 0) {
-                    return 0;
-                }
-                buf[offset] = content.charAt(index++);
-                return 1;
-            }
-        };
         final CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setDelimiter("[|]").setEscape('!').get();
-        try (CSVParser csvParser = csvFormat.parse(chunked)) {
+        try (CSVParser csvParser = csvFormat.parse(new ChunkedReader("a[|]b\r\nc![!|!]d[|]e"))) {
             CSVRecord csvRecord = csvParser.nextRecord();
             assertEquals("a", csvRecord.get(0));
             assertEquals("b", csvRecord.get(1));

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -1710,6 +1710,47 @@ class CSVParserTest {
     }
 
     @Test
+    void testParseWithDelimiterStringFromChunkedReader() throws IOException {
+        // A reader that hands out one character at a time and never reports itself ready, like a socket or pipe.
+        final Reader chunked = new Reader() {
+
+            private final String content = "a[|]b\r\nc![!|!]d[|]e";
+            private int index;
+
+            @Override
+            public void close() {
+                // nothing to close
+            }
+
+            @Override
+            public boolean ready() {
+                return false;
+            }
+
+            @Override
+            public int read(final char[] buf, final int offset, final int length) {
+                if (index >= content.length()) {
+                    return -1;
+                }
+                if (length <= 0) {
+                    return 0;
+                }
+                buf[offset] = content.charAt(index++);
+                return 1;
+            }
+        };
+        final CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setDelimiter("[|]").setEscape('!').get();
+        try (CSVParser csvParser = csvFormat.parse(chunked)) {
+            CSVRecord csvRecord = csvParser.nextRecord();
+            assertEquals("a", csvRecord.get(0));
+            assertEquals("b", csvRecord.get(1));
+            csvRecord = csvParser.nextRecord();
+            assertEquals("c[|]d", csvRecord.get(0));
+            assertEquals("e", csvRecord.get(1));
+        }
+    }
+
+    @Test
     void testParseWithDelimiterStringWithQuote() throws IOException {
         final String source = "'a[|]b[|]c'[|]xyz\r\nabc[abc][|]xyz";
         final CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setDelimiter("[|]").setQuote('\'').get();

--- a/src/test/java/org/apache/commons/csv/ChunkedReader.java
+++ b/src/test/java/org/apache/commons/csv/ChunkedReader.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.csv;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+/**
+ * A {@link StringReader} that hands out one character per call and never reports itself ready, like a socket or a pipe that delivers data in chunks.
+ */
+final class ChunkedReader extends StringReader {
+
+    ChunkedReader(final String content) {
+        super(content);
+    }
+
+    @Override
+    public int read(final char[] buf, final int offset, final int length) throws IOException {
+        return length <= 0 ? 0 : super.read(buf, offset, 1);
+    }
+
+    @Override
+    public boolean ready() {
+        return false;
+    }
+}

--- a/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
+++ b/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
@@ -273,39 +273,4 @@ class ExtendedBufferedReaderTest {
             assertEquals('b', peeked[1]);
         }
     }
-
-    /**
-     * A reader that returns one character per call and never reports itself ready, like a socket or pipe that delivers data in chunks.
-     */
-    private static final class ChunkedReader extends java.io.Reader {
-
-        private final String content;
-        private int index;
-
-        ChunkedReader(final String content) {
-            this.content = content;
-        }
-
-        @Override
-        public void close() {
-            // nothing to close
-        }
-
-        @Override
-        public boolean ready() {
-            return false;
-        }
-
-        @Override
-        public int read(final char[] buf, final int offset, final int length) {
-            if (index >= content.length()) {
-                return EOF;
-            }
-            if (length <= 0) {
-                return 0;
-            }
-            buf[offset] = content.charAt(index++);
-            return 1;
-        }
-    }
 }

--- a/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
+++ b/src/test/java/org/apache/commons/csv/ExtendedBufferedReaderTest.java
@@ -240,4 +240,72 @@ class ExtendedBufferedReaderTest {
             assertEquals('d', br.getLastChar());
         }
     }
+
+    @Test
+    void testReadAndPeekArrayFromChunkedReader() throws Exception {
+        try (ExtendedBufferedReader br = new ExtendedBufferedReader(new ChunkedReader("abcdef"))) {
+            final char[] peeked = new char[3];
+            assertEquals(3, br.peek(peeked));
+            assertArrayEquals(new char[] { 'a', 'b', 'c' }, peeked);
+            final char[] read = new char[3];
+            assertEquals(3, br.read(read, 0, 3));
+            assertArrayEquals(new char[] { 'a', 'b', 'c' }, read);
+        }
+    }
+
+    @Test
+    void testReadArrayPastEndOfChunkedReader() throws Exception {
+        try (ExtendedBufferedReader br = new ExtendedBufferedReader(new ChunkedReader("ab"))) {
+            final char[] read = new char[4];
+            assertEquals(2, br.read(read, 0, 4));
+            assertEquals('a', read[0]);
+            assertEquals('b', read[1]);
+            assertEquals(EOF, br.read(read, 0, 4));
+        }
+    }
+
+    @Test
+    void testPeekArrayPastEndOfChunkedReader() throws Exception {
+        try (ExtendedBufferedReader br = new ExtendedBufferedReader(new ChunkedReader("ab"))) {
+            final char[] peeked = new char[4];
+            assertEquals(2, br.peek(peeked));
+            assertEquals('a', peeked[0]);
+            assertEquals('b', peeked[1]);
+        }
+    }
+
+    /**
+     * A reader that returns one character per call and never reports itself ready, like a socket or pipe that delivers data in chunks.
+     */
+    private static final class ChunkedReader extends java.io.Reader {
+
+        private final String content;
+        private int index;
+
+        ChunkedReader(final String content) {
+            this.content = content;
+        }
+
+        @Override
+        public void close() {
+            // nothing to close
+        }
+
+        @Override
+        public boolean ready() {
+            return false;
+        }
+
+        @Override
+        public int read(final char[] buf, final int offset, final int length) {
+            if (index >= content.length()) {
+                return EOF;
+            }
+            if (length <= 0) {
+                return 0;
+            }
+            buf[offset] = content.charAt(index++);
+            return 1;
+        }
+    }
 }


### PR DESCRIPTION
Thanks for maintaining this! `ExtendedBufferedReader.peek(char[])` and `read(char[], int, int)` inherit a buffered read that returns as soon as the source reports it is not ready, so a `Reader` backed by a socket or a pipe hands back a short read and the delimiter lookahead is matched against a half-filled buffer.

Two things go wrong once the buffer is short:

- `Lexer.isDelimiter` / `isEscapeDelimiter` compare every slot, so the still-zeroed tail makes a multi-character delimiter that is really present look like ordinary text. Parsing `a[|]b` with delimiter `[|]` yields one field `a[|]b` from a chunked reader and two fields `a`, `b` from a `StringReader` for the same bytes, which is a parser differential if the split feeds any filtering or routing decision.
- `CSVFormat.printWithEscapes(Reader, Appendable)` builds its lookahead the same way, so printing the single value `x[|]y` from a chunked reader writes the delimiter unescaped and the record reads back as two fields.

Both call sites share the same reader, so the loop lives there rather than in each caller. Added a regression test at the reader level and one at the parser level; both fail without the change. `mvn` is green including the coverage gate.
