### PR TITLE
Keep an escaped value that equals the null string

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -806,8 +806,10 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         final String nullString = format.getNullString();
         final boolean strictQuoteMode = isStrictQuoteMode();
         if (input.equals(nullString)) {
+            // An escaped value is the null string itself, not the null marker: printing null writes the null string
+            // verbatim, so "\\N" for nullString "\N" can only have come from a value that really is "\N".
             // nullString = NULL(String), distinguish between "NULL" and NULL in ALL_NON_NULL or NON_NUMERIC quote mode
-            return strictQuoteMode && isQuoted ? input : null;
+            return reusableToken.isEscaped || strictQuoteMode && isQuoted ? input : null;
         }
         // don't set nullString, distinguish between "" and ,, (absent values) in All_NON_NULL or NON_NUMERIC quote mode
         return strictQuoteMode && nullString == null && input.isEmpty() && !isQuoted ? null : input;

--- a/src/main/java/org/apache/commons/csv/CSVParser.java
+++ b/src/main/java/org/apache/commons/csv/CSVParser.java
@@ -806,10 +806,11 @@ public final class CSVParser implements Iterable<CSVRecord>, Closeable {
         final String nullString = format.getNullString();
         final boolean strictQuoteMode = isStrictQuoteMode();
         if (input.equals(nullString)) {
-            // An escaped value is the null string itself, not the null marker: printing null writes the null string
-            // verbatim, so "\\N" for nullString "\N" can only have come from a value that really is "\N".
+            // A token that needed an escape translation cannot be the null marker: printing null emits the null
+            // string without escaping it (it may be quoted, but never escaped), so an escaped "\N" for nullString
+            // "\N" can only have come from a field whose value really is "\N".
             // nullString = NULL(String), distinguish between "NULL" and NULL in ALL_NON_NULL or NON_NUMERIC quote mode
-            return reusableToken.isEscaped || strictQuoteMode && isQuoted ? input : null;
+            return reusableToken.isEscaped || (strictQuoteMode && isQuoted) ? input : null;
         }
         // don't set nullString, distinguish between "" and ,, (absent values) in All_NON_NULL or NON_NUMERIC quote mode
         return strictQuoteMode && nullString == null && input.isEmpty() && !isQuoted ? null : input;

--- a/src/main/java/org/apache/commons/csv/Lexer.java
+++ b/src/main/java/org/apache/commons/csv/Lexer.java
@@ -76,12 +76,15 @@ final class Lexer implements Closeable {
     private void appendNextEscapedCharacterToToken(final Token token) throws IOException {
         if (isEscapeDelimiter()) {
             token.content.append(delimiter);
+            token.isEscaped = true;
         } else {
             final int unescaped = readEscape();
             if (unescaped == EOF) { // unexpected char after escape
+                // The escape character is kept verbatim, so nothing was translated.
                 token.content.append((char) escape).append((char) reader.getLastChar());
             } else {
                 token.content.append((char) unescaped);
+                token.isEscaped = true;
             }
         }
     }

--- a/src/main/java/org/apache/commons/csv/Token.java
+++ b/src/main/java/org/apache/commons/csv/Token.java
@@ -61,11 +61,15 @@ final class Token {
 
     boolean isQuoted;
 
+    /** True when an escape sequence in the input was translated while building {@link #content}. */
+    boolean isEscaped;
+
     void reset() {
         content.setLength(0);
         type = INVALID;
         isReady = false;
         isQuoted = false;
+        isEscaped = false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -587,7 +587,7 @@ class CSVParserTest {
     @ParameterizedTest
     @EnumSource(value = CSVFormat.Predefined.class, names = { "MySQL", "PostgreSQLCsv", "PostgreSQLText", "Oracle" })
     void testEscapedNullStringIsAValue(final CSVFormat.Predefined predefined) throws Exception {
-        // For formats whose null string is "\\N" (e.g., MySQL, PostgreSQL Text, Oracle), 
+        // For formats whose null string is "\\N" (e.g., MySQL, PostgreSQL Text, Oracle),
         // a literal value "\\N" must be written as "\\\\N" so it is not read back as null.
         final CSVFormat format = predefined.getFormat();
         final StringWriter writer = new StringWriter();

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -584,19 +584,19 @@ class CSVParserTest {
         }
     }
 
-    @Test
-    void testEscapedNullStringIsAValue() throws Exception {
+    @ParameterizedTest
+    @EnumSource(value = CSVFormat.Predefined.class, names = { "MySQL", "PostgreSQLCsv", "PostgreSQLText", "Oracle" })
+    void testEscapedNullStringIsAValue(final CSVFormat.Predefined predefined) throws Exception {
         // "\N" is the MySQL and PostgreSQL null marker, "\\N" is the value "\N", which is what the printer writes for it.
-        for (final CSVFormat format : new CSVFormat[] { CSVFormat.MYSQL, CSVFormat.POSTGRESQL_TEXT, CSVFormat.ORACLE }) {
-            final StringWriter writer = new StringWriter();
-            try (CSVPrinter printer = new CSVPrinter(writer, format)) {
-                printer.printRecord("\\N", null);
-            }
-            try (CSVParser parser = CSVParser.parse(writer.toString(), format)) {
-                final CSVRecord record = parser.nextRecord();
-                assertEquals("\\N", record.get(0), format.toString());
-                assertNull(record.get(1), format.toString());
-            }
+        final CSVFormat format = predefined.getFormat();
+        final StringWriter writer = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(writer, format)) {
+            printer.printRecord("\\N", null);
+        }
+        try (CSVParser parser = CSVParser.parse(writer.toString(), format)) {
+            final CSVRecord record = parser.nextRecord();
+            assertEquals("\\N", record.get(0));
+            assertNull(record.get(1));
         }
     }
 

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -587,7 +587,7 @@ class CSVParserTest {
     @ParameterizedTest
     @EnumSource(value = CSVFormat.Predefined.class, names = { "MySQL", "PostgreSQLCsv", "PostgreSQLText", "Oracle" })
     void testEscapedNullStringIsAValue(final CSVFormat.Predefined predefined) throws Exception {
-        // "\N" is the MySQL and PostgreSQL null marker, "\\N" is the value "\N", which is what the printer writes for it.
+        // For formats whose null string is "\\N" (e.g., MySQL, PostgreSQL Text, Oracle), a literal value "\\N" must be written as "\\\\N" so it is not read back as null.
         final CSVFormat format = predefined.getFormat();
         final StringWriter writer = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(writer, format)) {

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -587,7 +587,8 @@ class CSVParserTest {
     @ParameterizedTest
     @EnumSource(value = CSVFormat.Predefined.class, names = { "MySQL", "PostgreSQLCsv", "PostgreSQLText", "Oracle" })
     void testEscapedNullStringIsAValue(final CSVFormat.Predefined predefined) throws Exception {
-        // For formats whose null string is "\\N" (e.g., MySQL, PostgreSQL Text, Oracle), a literal value "\\N" must be written as "\\\\N" so it is not read back as null.
+        // For formats whose null string is "\\N" (e.g., MySQL, PostgreSQL Text, Oracle), 
+        // a literal value "\\N" must be written as "\\\\N" so it is not read back as null.
         final CSVFormat format = predefined.getFormat();
         final StringWriter writer = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(writer, format)) {

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -585,6 +585,22 @@ class CSVParserTest {
     }
 
     @Test
+    void testEscapedNullStringIsAValue() throws Exception {
+        // "\N" is the MySQL and PostgreSQL null marker, "\\N" is the value "\N", which is what the printer writes for it.
+        for (final CSVFormat format : new CSVFormat[] { CSVFormat.MYSQL, CSVFormat.POSTGRESQL_TEXT, CSVFormat.ORACLE }) {
+            final StringWriter writer = new StringWriter();
+            try (CSVPrinter printer = new CSVPrinter(writer, format)) {
+                printer.printRecord("\\N", null);
+            }
+            try (CSVParser parser = CSVParser.parse(writer.toString(), format)) {
+                final CSVRecord record = parser.nextRecord();
+                assertEquals("\\N", record.get(0), format.toString());
+                assertNull(record.get(1), format.toString());
+            }
+        }
+    }
+
+    @Test
     void testExcelFormat1() throws IOException {
         final String code = "value1,value2,value3,value4\r\na,b,c,d\r\n  x,,,\r\n\r\n\"\"\"hello\"\"\",\"  \"\"world\"\"\",\"abc\ndef\",\r\n";
         final String[][] res = { { "value1", "value2", "value3", "value4" }, { "a", "b", "c", "d" }, { "  x", "", "", "" }, { "" },

--- a/src/test/java/org/apache/commons/csv/CSVParserTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVParserTest.java
@@ -587,16 +587,17 @@ class CSVParserTest {
     @ParameterizedTest
     @EnumSource(value = CSVFormat.Predefined.class, names = { "MySQL", "PostgreSQLCsv", "PostgreSQLText", "Oracle" })
     void testEscapedNullStringIsAValue(final CSVFormat.Predefined predefined) throws Exception {
-        // For formats whose null string is "\\N" (e.g., MySQL, PostgreSQL Text, Oracle),
-        // a literal value "\\N" must be written as "\\\\N" so it is not read back as null.
+        // "\N" is the null string for MySQL, PostgreSQL Text and Oracle; PostgreSQL CSV uses an empty null
+        // string. In every case a field whose value equals "\N" must round trip as that value, not as null.
+        final String valueEqualToNullString = "\\N";
         final CSVFormat format = predefined.getFormat();
         final StringWriter writer = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(writer, format)) {
-            printer.printRecord("\\N", null);
+            printer.printRecord(valueEqualToNullString, null);
         }
         try (CSVParser parser = CSVParser.parse(writer.toString(), format)) {
             final CSVRecord record = parser.nextRecord();
-            assertEquals("\\N", record.get(0));
+            assertEquals(valueEqualToNullString, record.get(0));
             assertNull(record.get(1));
         }
     }

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -157,13 +157,17 @@ class CSVPrinterTest {
     }
 
     /**
-     * Converts an input CSV array into expected output values, including NULLs. NULL strings are converted to null values because the parser will convert
-     * these strings to null.
+     * Converts an input CSV array into expected output values, including NULLs. A value equal to the null string is converted to null only when the printer
+     * writes that value unchanged; when the printer escapes or quotes it, the parser reads it back as the value it is.
      */
-    private <T> T[] expectNulls(final T[] original, final CSVFormat csvFormat) {
+    private <T> T[] expectNulls(final T[] original, final CSVFormat csvFormat) throws IOException {
         final T[] fixed = original.clone();
+        final String nullString = csvFormat.getNullString();
+        if (nullString == null || !printsVerbatim(csvFormat, nullString)) {
+            return fixed;
+        }
         for (int i = 0; i < fixed.length; i++) {
-            if (Objects.equals(csvFormat.getNullString(), fixed[i])) {
+            if (Objects.equals(nullString, fixed[i])) {
                 fixed[i] = null;
             }
         }
@@ -185,6 +189,13 @@ class CSVPrinterTest {
     private Connection getH2Connection() throws SQLException, ClassNotFoundException {
         Class.forName("org.h2.Driver");
         return DriverManager.getConnection("jdbc:h2:mem:my_test;", "sa", "");
+    }
+
+    /** Tests whether the format prints the given value unchanged, in which case the parser cannot tell it from the null string. */
+    private boolean printsVerbatim(final CSVFormat csvFormat, final String value) throws IOException {
+        final StringBuilder sb = new StringBuilder();
+        csvFormat.print(value, sb, true);
+        return value.contentEquals(sb);
     }
 
     private CSVPrinter printWithHeaderComments(final StringWriter sw, final Date now, final CSVFormat baseFormat) throws IOException {

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -157,8 +157,9 @@ class CSVPrinterTest {
     }
 
     /**
-     * Converts an input CSV array into expected output values, including NULLs. A value equal to the null string is converted to null only when the printer
-     * writes that value unchanged; when the printer escapes or quotes it, the parser reads it back as the value it is.
+     * Converts an input CSV array into expected output values, including NULLs. A value equal to the null string is expected back as null only when the
+     * printer writes it verbatim (neither escaped nor quoted); once it is escaped or quoted the parser can tell it apart from a real null and reads it back
+     * as the value it is.
      */
     private <T> T[] expectNulls(final T[] original, final CSVFormat csvFormat) throws IOException {
         final T[] fixed = original.clone();


### PR DESCRIPTION
`CSVParser.handleNull` compares the fully unescaped token against the format's null string, so a value that really is `\N` and that the printer correctly wrote as `\\N` for `MYSQL`, `POSTGRESQL_TEXT`, `POSTGRESQL_CSV` and `ORACLE` comes back as `null`; the lexer now records whether an escape sequence was actually translated, and only an untranslated token can be the null marker.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
