### PR TITLE
Count rows produced instead of getRow() in printRecords(ResultSet)

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVPrinter.java
+++ b/src/main/java/org/apache/commons/csv/CSVPrinter.java
@@ -502,7 +502,11 @@ public final class CSVPrinter implements Flushable, Closeable {
      */
     public void printRecords(final ResultSet resultSet) throws SQLException, IOException {
         final int columnCount = resultSet.getMetaData().getColumnCount();
-        while (resultSet.next() && format.useRow(resultSet.getRow())) {
+        // Count the rows produced here instead of ResultSet.getRow(): getRow() is the absolute cursor
+        // position, which is optional for TYPE_FORWARD_ONLY result sets and returns 0 there, silently
+        // disabling maxRows. Mirrors the row-produced counter the parser uses (CSV-327).
+        long rowCount = 0;
+        while (format.useRow(rowCount + 1) && resultSet.next()) {
             lock.lock();
             try {
                 for (int i = 1; i <= columnCount; i++) {
@@ -523,6 +527,7 @@ public final class CSVPrinter implements Flushable, Closeable {
             } finally {
                 lock.unlock();
             }
+            rowCount++;
         }
     }
 

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -51,6 +51,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -962,6 +963,30 @@ class CSVPrinterTest {
             }
             assertRowCount(format, sw.toString(), TABLE_AND_HEADER_RECORD_COUNT);
         }
+    }
+
+    @Test
+    void testJdbcPrinterWithResultSetWithoutRowNumber() throws IOException, SQLException {
+        // JDBC makes ResultSet.getRow() optional for TYPE_FORWARD_ONLY result sets, where a driver may return 0.
+        // maxRows must still cap the output by rows produced rather than by getRow().
+        final StringWriter sw = new StringWriter();
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setMaxRows(2).get();
+        try (SimpleResultSet resultSet = new SimpleResultSet() {
+            @Override
+            public int getRow() {
+                return 0;
+            }
+        }) {
+            resultSet.addColumn("ID", Types.INTEGER, 10, 0);
+            for (int i = 1; i <= 4; i++) {
+                resultSet.addRow(i);
+            }
+            try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+                printer.printRecords(resultSet);
+                assertEquals(2, printer.getRecordCount());
+            }
+        }
+        assertEquals("1" + RECORD_SEPARATOR + "2" + RECORD_SEPARATOR, sw.toString());
     }
 
     @Test


### PR DESCRIPTION
`printRecords(ResultSet)` caps `maxRows` with `resultSet.getRow()`, the absolute cursor position. JDBC makes `getRow()` optional for `TYPE_FORWARD_ONLY` result sets and a driver can return `0` there, so `useRow(0)` stays true and the cap is silently skipped while the whole result set streams out; it is also off for a pre-positioned result set. Count the rows produced by this call instead, matching the parser's row-produced counter from CSV-327.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
