### PR TITLE
Handle null name in CSVRecord accessors under ignoreHeaderCase

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVRecord.java
+++ b/src/main/java/org/apache/commons/csv/CSVRecord.java
@@ -127,7 +127,7 @@ public final class CSVRecord implements Serializable, Iterable<String> {
         if (headerMap == null) {
             throw new IllegalStateException("No header mapping was specified, the record values can't be accessed by name");
         }
-        final Integer index = headerMap.get(name);
+        final Integer index = name == null ? null : headerMap.get(name);
         if (index == null) {
             throw new IllegalArgumentException(String.format("Mapping for %s not found, expected one of %s", name, headerMap.keySet()));
         }
@@ -243,7 +243,7 @@ public final class CSVRecord implements Serializable, Iterable<String> {
      */
     public boolean isMapped(final String name) {
         final Map<String, Integer> headerMap = getHeaderMapRaw();
-        return headerMap != null && headerMap.containsKey(name);
+        return name != null && headerMap != null && headerMap.containsKey(name);
     }
 
     /**

--- a/src/test/java/org/apache/commons/csv/CSVRecordTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVRecordTest.java
@@ -44,6 +44,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class CSVRecordTest {
 
@@ -226,6 +228,22 @@ class CSVRecordTest {
         assertFalse(record.isSet("first"));
         assertTrue(recordWithHeader.isSet(EnumHeader.FIRST.name()));
         assertFalse(recordWithHeader.isSet("DOES NOT EXIST"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void testNullNameAccessorsMatchAcrossIgnoreHeaderCase(final boolean ignoreHeaderCase) throws IOException {
+        final CSVFormat format = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setIgnoreHeaderCase(ignoreHeaderCase).get();
+        try (CSVParser parser = CSVParser.parse("A,B\n1,2", format)) {
+            final CSVRecord rec = parser.iterator().next();
+            // A null name is never a mapped header, so the boolean guards return false rather than throwing,
+            // regardless of ignoreHeaderCase (the case-insensitive header map rejects null keys).
+            assertFalse(rec.isMapped(null));
+            assertFalse(rec.isSet((String) null));
+            // A null name (also reached from get((Enum) null)) reports a missing mapping, not an NPE.
+            assertThrows(IllegalArgumentException.class, () -> rec.get((String) null));
+            assertThrows(IllegalArgumentException.class, () -> rec.get((Enum<?>) null));
+        }
     }
 
     @Test


### PR DESCRIPTION
`ignoreHeaderCase` backs the header map with a `TreeMap` on `String.CASE_INSENSITIVE_ORDER` whose comparator rejects null keys, so a null name throws `NullPointerException` from `CSVRecord.isMapped`/`isSet`/`get` (and `get(Enum)` with a null enum) where the default `LinkedHashMap` path returns `false` or throws the documented `IllegalArgumentException`. guard the null name in `isMapped` (a null name is never a mapped header) and `get` (report the missing mapping) so the contract is the same regardless of `ignoreHeaderCase`; `isSet` is fixed transitively. found by passing a null name to the accessors under `ignoreHeaderCase`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
