### PR TITLE
Quote null value that starts a record in minimal quote mode

### DIFF
--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2135,6 +2135,15 @@ public final class CSVFormat implements Serializable {
     }
 
     /**
+     * Tests whether the quote policy encapsulates values only when needed, which is also the policy when none is set.
+     *
+     * @return {@code true} if the {@link QuoteMode} is {@link QuoteMode#MINIMAL} or unset.
+     */
+    private boolean isMinimalQuoteMode() {
+        return quoteMode == null || quoteMode == QuoteMode.MINIMAL;
+    }
+
+    /**
      * Tests whether a null string has been defined.
      *
      * @return {@code true} if a nullString is defined
@@ -2272,7 +2281,17 @@ public final class CSVFormat implements Serializable {
                 out.append(getDelimiterString());
             }
             if (object == null) {
-                out.append(value);
+                if (len == 0 && newRecord && isQuoteCharacterSet() && isMinimalQuoteMode()) {
+                    // Encapsulate like printWithQuotes does for an empty value that starts a record: an
+                    // unquoted one makes the whole line empty, and a parser with ignoreEmptyLines enabled
+                    // then drops the record. ALL_NON_NULL and NON_NUMERIC are excluded because they encode
+                    // null as the bare empty field.
+                    final char quoteChar = quoteCharacter.charValue(); // Explicit unboxing is intentional
+                    out.append(quoteChar);
+                    out.append(quoteChar);
+                } else {
+                    out.append(value);
+                }
             } else if (isQuoteCharacterSet()) {
                 // The original object is needed so can check for Number
                 printWithQuotes(object, value, out, newRecord);

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -2284,8 +2284,8 @@ public final class CSVFormat implements Serializable {
                 if (len == 0 && newRecord && isQuoteCharacterSet() && isMinimalQuoteMode()) {
                     // Encapsulate like printWithQuotes does for an empty value that starts a record: an
                     // unquoted one makes the whole line empty, and a parser with ignoreEmptyLines enabled
-                    // then drops the record. ALL_NON_NULL and NON_NUMERIC are excluded because they encode
-                    // null as the bare empty field.
+                    // then drops the record. ALL, ALL_NON_NULL, and NON_NUMERIC are excluded because they
+                    // encode null as the bare empty field, distinct from a quoted empty string (CSV-203).
                     final char quoteChar = quoteCharacter.charValue(); // Explicit unboxing is intentional
                     out.append(quoteChar);
                     out.append(quoteChar);

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -1557,7 +1557,7 @@ class CSVFormatTest {
         assertNotEquals(csvFormat, csvFormatTwo); // CSV-244 - should not be equal
 
         assertNotEquals(csvFormatTwo, csvFormat); // CSV-244 - should not be equal
-        assertEquals(",,,,,,,", string);
+        assertEquals("\"\",,,,,,,", string);
 
     }
 

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -188,6 +188,14 @@ class CSVPrinterTest {
         return DriverManager.getConnection("jdbc:h2:mem:my_test;", "sa", "");
     }
 
+    private String printNullRecord(final CSVFormat format) throws IOException {
+        final StringWriter sw = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(sw, format)) {
+            printer.printRecord((Object) null);
+        }
+        return sw.toString();
+    }
+
     private CSVPrinter printWithHeaderComments(final StringWriter sw, final Date now, final CSVFormat baseFormat) throws IOException {
         // Use withHeaderComments first to test CSV-145
         // @formatter:off
@@ -1722,6 +1730,29 @@ class CSVPrinterTest {
     }
 
     @Test
+    void testPrintNullValueStartingRecord() throws IOException {
+        final StringWriter sw = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT)) {
+            printer.printRecord("a");
+            printer.printRecord((Object) null);
+            printer.printRecord("b");
+        }
+        final String csv = sw.toString();
+        assertEquals("a" + RECORD_SEPARATOR + "\"\"" + RECORD_SEPARATOR + "b" + RECORD_SEPARATOR, csv);
+        try (CSVParser parser = CSVParser.parse(csv, CSVFormat.DEFAULT)) {
+            final List<CSVRecord> records = parser.getRecords();
+            assertEquals(3, records.size());
+            assertArrayEquals(new String[] { "" }, records.get(1).values());
+        }
+        // An explicit MINIMAL quote mode encapsulates it too.
+        assertEquals("\"\"" + RECORD_SEPARATOR, printNullRecord(CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.MINIMAL).get()));
+        // ALL_NON_NULL encodes null as the bare empty field, so it must stay unquoted.
+        assertEquals(RECORD_SEPARATOR, printNullRecord(CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL_NON_NULL).get()));
+        // Without a quote character there is nothing to encapsulate with.
+        assertEquals(RECORD_SEPARATOR, printNullRecord(CSVFormat.DEFAULT.builder().setQuote(null).get()));
+    }
+
+    @Test
     void testPrintNullValues() throws IOException {
         final StringWriter sw = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT)) {
@@ -1854,8 +1885,8 @@ class CSVPrinterTest {
             printer.printRecords(objectArray);
             assertEquals(objectArray.length, printer.getRecordCount());
         }
-        assertEquals(6, charArrayWriter.size());
-        assertEquals("\n\n\n\n\n\n", charArrayWriter.toString());
+        assertEquals(16, charArrayWriter.size());
+        assertEquals("\"\"\n\"\"\n\"\"\n\n\"\"\n\"\"\n", charArrayWriter.toString());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVPrinterTest.java
@@ -1746,6 +1746,8 @@ class CSVPrinterTest {
         }
         // An explicit MINIMAL quote mode encapsulates it too.
         assertEquals("\"\"" + RECORD_SEPARATOR, printNullRecord(CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.MINIMAL).get()));
+        // ALL encodes null as the bare empty field, distinct from a quoted empty string (CSV-203).
+        assertEquals(RECORD_SEPARATOR, printNullRecord(CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).get()));
         // ALL_NON_NULL encodes null as the bare empty field, so it must stay unquoted.
         assertEquals(RECORD_SEPARATOR, printNullRecord(CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL_NON_NULL).get()));
         // Without a quote character there is nothing to encapsulate with.
@@ -1885,8 +1887,9 @@ class CSVPrinterTest {
             printer.printRecords(objectArray);
             assertEquals(objectArray.length, printer.getRecordCount());
         }
-        assertEquals(16, charArrayWriter.size());
-        assertEquals("\"\"\n\"\"\n\"\"\n\n\"\"\n\"\"\n", charArrayWriter.toString());
+        final String expected = "\"\"\n\"\"\n\"\"\n\n\"\"\n\"\"\n";
+        assertEquals(expected.length(), charArrayWriter.size());
+        assertEquals(expected, charArrayWriter.toString());
     }
 
     @Test


### PR DESCRIPTION
`print(Object, CharSequence, Appendable, boolean)` sends a null value straight to `out.append(value)` and never reaches `printWithQuotes`, so the encapsulation `MINIMAL` does for an empty value at the start of a record is skipped. That rule exists precisely for this case, as its own comment says an empty line has no tokens. The result is that a record whose first value is null, and whose null string renders empty, prints as a blank line. `CSVFormat.DEFAULT` enables `ignoreEmptyLines`, so the record is silently dropped when the output is read back: printing `[a]`, `[null]`, `[b]` gives `a\r\n\r\nb\r\n`, which parses as 2 records. The same loss hits any `DEFAULT`-derived format, including `MONGODB_CSV` and `INFORMIX_UNLOAD`, and any format using `setNullString("")`. Found round-tripping printer output with null values back through the parser.

The fix encapsulates the empty null value when it starts a record, a quote character is set, and the quote mode is `MINIMAL` or unset, which is the same condition `printWithQuotes` already applies to an empty `CharSequence`. `ALL_NON_NULL` and `NON_NUMERIC` are left alone since they use the bare empty field to encode null, and formats without a quote character have nothing to encapsulate with. Two existing assertions move because a leading null now prints like a leading `""`; `testPrintRecordsWithObjectArray` was pinning six blank lines for six records, which is the bug itself.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
